### PR TITLE
📦️ Use the three `hora-skills-ort-*` packages instead of `hora-skills`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
         "@openreachtech/eslint-config": "^4.5.0",
         "@openreachtech/hora": "^0.4.0",
         "@openreachtech/hora-ecosystem": "^0.0.0",
-        "@openreachtech/hora-skills": "^0.4.0",
+        "@openreachtech/hora-skills-ort-core": "^0.0.0",
+        "@openreachtech/hora-skills-ort-furo": "^0.0.0",
+        "@openreachtech/hora-skills-ort-renchan": "^0.0.0",
         "eslint": "^9.39.5"
       }
     },
@@ -307,17 +309,34 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/@openreachtech/hora-skills": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@openreachtech/hora-skills/-/hora-skills-0.4.0.tgz",
-      "integrity": "sha512-nHcBw/26CZ8SjLDczJVyKmUbWL39cDoMQ4mKJDfAoImebjjBH2OavJCtgvYIiyH+uDw9SWCy9RaoiyACYsOxbA==",
+    "node_modules/@openreachtech/hora-skills-ort-core": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@openreachtech/hora-skills-ort-core/-/hora-skills-ort-core-0.0.0.tgz",
+      "integrity": "sha512-e4RAvypm8cglVj+O/CQmJw1nPHDM/fmEzR2TnhPghyQ8+wi6M60kw7fTvFfSkpi1KckiSHnIUqEDMH1T7ZDaeg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "hora-skills": "lib/equip/hora-skills.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
+        "hora-skills-ort-core": "lib/equip/hora-skills-ort-core.js"
+      }
+    },
+    "node_modules/@openreachtech/hora-skills-ort-furo": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@openreachtech/hora-skills-ort-furo/-/hora-skills-ort-furo-0.0.0.tgz",
+      "integrity": "sha512-GGrv44w4fjCfh2T2RlXVfbyl15q51OgUcTcmwhN+ynfPAOvxrabCPru/gueccslo2FpTwN96076oc8TWOzyCSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "hora-skills-ort-furo": "lib/equip/hora-skills-ort-furo.js"
+      }
+    },
+    "node_modules/@openreachtech/hora-skills-ort-renchan": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@openreachtech/hora-skills-ort-renchan/-/hora-skills-ort-renchan-0.0.0.tgz",
+      "integrity": "sha512-AFfbDilFtNIVyfyx/4ZM08izxTi4F5clFRVpfvuFinWk0PTfvg938azOye9fG7EUtql1Ik6FIzbfLOJuWDffxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "hora-skills-ort-renchan": "lib/equip/hora-skills-ort-renchan.js"
       }
     },
     "node_modules/@pkgr/core": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "description": "TODO: fulfill here",
   "type": "module",
   "scripts": {
-    "hora:init": "hora-core install && hora-skills install",
+    "hora:init": "hora-core install && hora-skills-ort-core install && hora-skills-ort-renchan install && hora-skills-ort-furo install",
     "l": "npm run lint",
     "lint": "eslint .",
     "lint:docs-pairs": "node scripts/check-docs-pairs.mjs",
@@ -18,7 +18,9 @@
     "@openreachtech/eslint-config": "^4.5.0",
     "@openreachtech/hora": "^0.4.0",
     "@openreachtech/hora-ecosystem": "^0.0.0",
-    "@openreachtech/hora-skills": "^0.4.0",
+    "@openreachtech/hora-skills-ort-core": "^0.0.0",
+    "@openreachtech/hora-skills-ort-furo": "^0.0.0",
+    "@openreachtech/hora-skills-ort-renchan": "^0.0.0",
     "eslint": "^9.39.5"
   }
 }


### PR DESCRIPTION
# Why

* Close #76

# How

* `hora-skills` was split into one package per domain, so this repository depends on all three: `@openreachtech/hora-skills-ort-core` (`hoc-`), `-ort-renchan` (`hor-`) and `-ort-furo` (`hof-`), each at `^0.0.0`
* `hora:init` equips each of them in turn — `hora-core install && hora-skills-ort-core install && hora-skills-ort-renchan install && hora-skills-ort-furo install`. Each package removes only what its own previous run installed, recorded in `.hora/<package name>.json`, so one never removes another one's skills
* The comments that name the old package in `.gitignore` and `eslint.config.js` follow in their own pull request
* The domain selection is gone with the split: a repository selects domains by selecting packages, so there is no `--domains` and no `horaSkills.domains` to carry here

The documents that describe the boundary follow in their own pull requests.
