### PR TITLE
🧵 Update the ignore rules for the three skills packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,11 +60,14 @@ id_ed25519
 /.claude/agents/*
 /.claude/skills/*
 
-# The two equip manifests, written by the install commands. These are the only
-# entries under .hora/ that are ignored: everything else there is the run's own
-# record, and `git log .hora/` is the history of what ran.
+# The four equip manifests, written by the install commands — one per package,
+# each named after the package that writes it. These are the only entries under
+# .hora/ that are ignored: everything else there is the run's own record, and
+# `git log .hora/` is the history of what ran.
 /.hora/equip-core.json
-/.hora/equip-skills.json
+/.hora/hora-skills-ort-core.json
+/.hora/hora-skills-ort-furo.json
+/.hora/hora-skills-ort-renchan.json
 
 #### for Windows
 Thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -47,11 +47,11 @@ id_ed25519
 # and committing it hands everyone else a set of allowances they never granted.
 /.claude/settings.local.json
 
-#### the kit equipped by postinstall, from @openreachtech/hora and
-#### @openreachtech/hora-skills (regenerated, not authored here)
+#### the kit equipped by postinstall, from @openreachtech/hora and the three
+#### @openreachtech/hora-skills-ort-* packages (regenerated, not authored here)
 #
 # Ignore the contents of both payload directories, and name this repository's
-# own entries back in, one literal line each. What the two packages distribute
+# own entries back in, one literal line each. What the packages distribute
 # changes with every release, so a pattern written against today's names goes
 # stale without saying so — and a denylist that stops matching says nothing
 # when it stops: every equipped entry would simply start being committed here.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,8 +43,8 @@ export default [
       '*-backend*/',
       '*-frontend*/',
 
-      // The kit equipped by postinstall, from @openreachtech/hora and
-      // @openreachtech/hora-skills. Not authored here, and some of the skills
+      // The kit equipped by postinstall, from @openreachtech/hora and the three
+      // @openreachtech/hora-skills-ort-* packages. Not authored here, and some of the skills
       // ship .js/.mjs/.cjs. Both payload directories are ignored whole, the way
       // .gitignore does it: a denylist written against the names the packages
       // use today says nothing when it stops matching. A skill this repository


### PR DESCRIPTION
# Why

* Close #78

# How

* Ignores the equip manifest of each of the three packages — `.hora/hora-skills-ort-core.json`, `-ort-furo.json`, `-ort-renchan.json`. Each package records its own installation under its own name, so the single `/.hora/equip-skills.json` line stopped matching anything and the three records would have started arriving as untracked files
* Updates the comments that name the packages whose payload is ignored, in `.gitignore` and in the lint ignores
* Neither payload rule itself changes: both stay allowlists over the whole of `.claude/agents/` and `.claude/skills/`, so nothing was written against `hc-*`/`hb-*`/`hf-*` and nothing has to be rewritten against `hoc-*`/`hor-*`/`hof-*`
