### PR TITLE
📄 Update the architecture document for the three packages

### DIFF
--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -33,14 +33,14 @@ Hora Kit が仕様書をアプリケーションに変えるまで。何がど�
 
 ## 4つの層
 
-![4つの層：/hora、5つの skill、ステージ skill と2つのエージェント、そして hora-skills](./images/layers.ja.svg)
+![4つの層：/hora、5つの skill、ステージ skill と2つのエージェント、そして3つのスキルパッケージ](./images/layers.ja.svg)
 
 | 層 | 決めること | 決してしないこと | 配布元 |
 |---|---|---|---|
 | `/hora` | 次にどの段階が来るか。すべてのブランチ・コミット・マージ | 作業の中身に関する一切 | `@openreachtech/hora` |
 | 5つの skill | 作業の順序と、各関所の終了条件 | その書き方 | `@openreachtech/hora` |
 | ステージ skill と2つの agent | 仕様書の1節、あるいは1関所ぶんのコードや判定 | 順序上の位置。git に関する一切 | `@openreachtech/hora` |
-| `hora-skills` | **すべての手順と、すべての合否基準** | それが呼ばれる時機 | `@openreachtech/hora-skills` |
+| 3つのスキルパッケージ | **すべての手順と、すべての合否基準** | それが呼ばれる時機 | `@openreachtech/hora-skills-ort-core`・`-ort-renchan`・`-ort-furo` |
 
 **4つのどれも、このリポジトリの中にはありません。** 4層すべてがパッケージとして届き、このリポジトリが持つのは仕様書と、これらの文書と、`.hora/` にある実行自身の記録です。
 
@@ -89,7 +89,7 @@ Hora Kit が仕様書をアプリケーションに変えるまで。何がど�
 
 **`hora-implementer` は git にも `.hora/` にも `specs/` にも触れません。** 1関所ぶん — または1関所の1単位ぶん — のコードとテストを書き、それ以外はすべて報告します。必要な依存、触ってはいけない共有ファイル、メインセッションに集約ファイルを再生成させたいフォルダ、変えたくなった contract、仕様書で見つけた問題です。[`/hora-build`](../.claude/skills/hora-build/SKILL.md) がその報告に基づいて動きます。
 
-**`hora-digester` は1つのファイルだけを書き、他はすべて読むだけです。** 出力は `.hora/digests/<skill-name>.md` で、ヘッダには由来した `hora-skills` のバージョンが入ります — だからダイジェストはインストール済みのバージョンと一致する間だけ使われ、パッケージが更新されれば、次に読まれる前に書き直されます。権威はスキル本体のままです。ダイジェストで解けない疑問が出た時点で、implementer が本体を開きます。
+**`hora-digester` は1つのファイルだけを書き、他はすべて読むだけです。** 出力は `.hora/digests/<skill-name>.md` で、ヘッダには由来したパッケージと、そのパッケージのバージョンが入ります — だからダイジェストはインストール済みのバージョンと一致する間だけ使われ、由来したパッケージが更新されれば、そのダイジェストは次に読まれる前に書き直されます。権威はスキル本体のままです。ダイジェストで解けない疑問が出た時点で、implementer が本体を開きます。
 
 **エージェントをここまで縛る理由：** 禁止の一つひとつが、「2人の書き手が衝突する経路」か「誰にも見えないところで決定が下される経路」を1本ずつ塞いでいます。
 
@@ -103,7 +103,7 @@ Hora Kit が仕様書をアプリケーションに変えるまで。何がど�
 .hora/
   tree/<repository>.md          /hora-setup が実地に読んだ内容と、読んだ時点のタグ
   digests/<skill-name>.md       equip 済みスキル1つの規約を短くしたもの。由来した
-                                hora-skills のバージョン付き
+                                由来したパッケージとバージョン付き
   spec/<version>/_stages.md     /hora-spec 自身の、どこまで進んだかの記録（第2部）
   spec/<version>/_assets.md     ステージ0 が何を、どこから、どのコミット時点で読んだか
   spec/<version>/_divergence.md 文書とコードの食い違い — 1件につき1行、各行はその
@@ -119,7 +119,9 @@ Hora Kit が仕様書をアプリケーションに変えるまで。何がど�
   glossary.md                   追記のみ。版で分けない
 
   equip-core.json               hora-core の install が置いたもの。gitignore 対象
-  equip-skills.json             hora-skills の install が置いたもの。gitignore 対象
+  hora-skills-ort-core.json     各スキルパッケージの install が置いたもの。
+  hora-skills-ort-furo.json     パッケージごとに1ファイル。gitignore 対象
+  hora-skills-ort-renchan.json
 ```
 
 `git log .hora/` が「何が走ったか」の履歴です。他に記録している場所はなく、必要もありません。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,14 +33,14 @@ This document explains the design. It is not the authority on any rule — each 
 
 ## Four layers
 
-![Four layers: /hora, the five skills, the stage skills and the two agents, and hora-skills](./images/layers.svg)
+![Four layers: /hora, the five skills, the stage skills and the two agents, and the three skills packages](./images/layers.svg)
 
 | Layer | What it decides | What it never decides | Ships in |
 |---|---|---|---|
 | `/hora` | which phase comes next; every branch, commit and merge | anything about the work itself | `@openreachtech/hora` |
 | the five skills | the order of the work, and each gate's exit condition | how any of it is written | `@openreachtech/hora` |
 | the stage skills and the two agents | one section of the spec, or one checkpoint's code or verdict | where they run in the order; anything about git | `@openreachtech/hora` |
-| `hora-skills` | **every procedure and every pass/fail criterion** | when it is invoked | `@openreachtech/hora-skills` |
+| the three skills packages | **every procedure and every pass/fail criterion** | when it is invoked | `@openreachtech/hora-skills-ort-core`, `-ort-renchan`, `-ort-furo` |
 
 **Not one of the four is in this repository.** All four arrive as packages, and what this repository holds is the spec, these documents, and the run's own record under `.hora/`.
 
@@ -89,7 +89,7 @@ Not everything can be delegated to a subagent, and the line is not about difficu
 
 **`hora-implementer` never touches git, `.hora/`, or `specs/`.** It writes code and tests for one checkpoint — or for one unit of one — and reports everything else: a dependency it needs, a shared file it must not edit, the folder whose aggregation file the main session should regenerate, a contract it wanted to change, a problem it found in the spec. [`/hora-build`](../.claude/skills/hora-build/SKILL.md) acts on the report.
 
-**`hora-digester` writes one file and reads everything else.** Its output is `.hora/digests/<skill-name>.md`, and the header names the `hora-skills` version it was derived from — so a digest is used only while it matches what is installed, and a package update leaves each one to be rewritten before it is read again. The skill itself stays the authority: an implementer opens it the moment its digest leaves a question open.
+**`hora-digester` writes one file and reads everything else.** Its output is `.hora/digests/<skill-name>.md`, and the header names the package it was derived from and that package's version — so a digest is used only while it matches what is installed, and an update of the package it came from leaves each of its digests to be rewritten before any is read again. The skill itself stays the authority: an implementer opens it the moment its digest leaves a question open.
 
 **Why the agents are so tightly bounded:** every one of those prohibitions removes a way for two writers to collide, or for a decision to be made where nobody can see it.
 
@@ -103,7 +103,7 @@ There is no state file. **The state is `.hora/`, and its checkboxes are the stat
 .hora/
   tree/<repository>.md          what /hora-setup read in the real tree, and the tag it read it at
   digests/<skill-name>.md       one equipped skill's conventions in short form, and the
-                                hora-skills version they came from
+                                package and version they came from
   spec/<version>/_stages.md     /hora-spec's own record of where it got to (Part 2)
   spec/<version>/_assets.md     what stage 0 read, where from, and at what commit
   spec/<version>/_divergence.md where the documents and the code disagree — one row
@@ -121,7 +121,9 @@ There is no state file. **The state is `.hora/`, and its checkboxes are the stat
   glossary.md                   append-only, not split per version
 
   equip-core.json               what the last hora-core install placed. Gitignored
-  equip-skills.json             what the last hora-skills install placed. Gitignored
+  hora-skills-ort-core.json     what the last install of each skills package placed —
+  hora-skills-ort-furo.json     one record per package. Gitignored
+  hora-skills-ort-renchan.json
 ```
 
 `git log .hora/` is the history of what ran. Nothing else records it, and nothing needs to.


### PR DESCRIPTION
# Why

* Close #82

# How

* The fourth layer is three packages now, so the layer table and the diagram alt text name them instead of the one
* **A digest header names the package as well as the version.** With one package a bare version was enough; with three it says nothing on its own, and an update of one package leaves only its own digests to be rewritten
* The `.hora/` tree names one equip record per package, in place of the single `equip-skills.json` that stopped being written

`npm run lint:docs-pairs` reports 10 pairs, 0 failures.
