### PR TITLE
📄 Update the README files for the three packages

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -74,7 +74,7 @@ npm install
 
 `specs/` を書く前に行ってください。リポジトリに自分のコミットができた後で `.git` を捨てると、それも一緒に失われます。
 
-**どちらの経路でも、`/hora` の前に新しいリポジトリで `npm install` を実行してください。実行しなければ、走らせる `/hora` がそもそも存在しません。** このリポジトリは skill も agent も自分では持ちません。`/hora` とそれが指揮する5つの skill は [`@openreachtech/hora`](https://github.com/openreachtech/hora-core) から、それらが委譲する手順は [`@openreachtech/hora-skills`](https://github.com/openreachtech/hora-skills) から来て、`postinstall` フックが両方を `.claude/` に配置します。clone 直後の `.claude/` は、それが走るまで空です。
+**どちらの経路でも、`/hora` の前に新しいリポジトリで `npm install` を実行してください。実行しなければ、走らせる `/hora` がそもそも存在しません。** このリポジトリは skill も agent も自分では持ちません。`/hora` とそれが指揮する5つの skill は [`@openreachtech/hora`](https://github.com/openreachtech/hora-core) から、それらが委譲する手順は3つのスキルパッケージ [`-ort-core`](https://github.com/openreachtech/hora-skills-ort-core)・[`-ort-renchan`](https://github.com/openreachtech/hora-skills-ort-renchan)・[`-ort-furo`](https://github.com/openreachtech/hora-skills-ort-furo) から来て、`postinstall` フックがそのすべてを `.claude/` に配置します。clone 直後の `.claude/` は、それが走るまで空です。
 
 3つ目のパッケージ `@openreachtech/hora-ecosystem` は、関所5が「新しく書く前に」確認するカタログです。どこにも配置されず、npm が置いた場所で読まれます。
 
@@ -181,7 +181,7 @@ $EDITOR specs/1.1.0/request/csv-export.md   # 欲しいものを、自分の言�
 
 18のチェックポイントは [`checkpoints.md`](./.claude/skills/hora-build/references/checkpoints.md) にあります。仕様、想定ユースケース、DB / API スキーマ、stub API、実装に必要なモジュール、actual API、worker、セキュリティ検証、そしてフロントエンド、最後に検収です。
 
-**Hora Kit が持つのは「順序」と「関所」だけで、「やり方」は持ちません。** resolver / migration / コンポーネント / テストの書き方も、受入レビューが何を見るかも、すべて [`@openreachtech/hora-skills`](https://github.com/openreachtech/hora-skills) にあります。`npm install` がこのリポジトリの `.claude/skills/` に配置します。詳しくは [`docs/skills.ja.md`](./docs/skills.ja.md) を参照してください。
+**Hora Kit が持つのは「順序」と「関所」だけで、「やり方」は持ちません。** resolver / migration / コンポーネント / テストの書き方も、受入レビューが何を見るかも、すべて `@openreachtech/hora-skills-ort-*` パッケージ（ドメインごとに1つ）にあります。`npm install` がこのリポジトリの `.claude/skills/` に配置します。詳しくは [`docs/skills.ja.md`](./docs/skills.ja.md) を参照してください。
 
 ## ドキュメント
 
@@ -213,7 +213,7 @@ npm run lint
 
 **`docs/` 配下は全てペアです** — `x.md` と `x.ja.md`。片方を直したら、同じコミットでもう片方も直してください。同じことを言う文書が2つあれば、片方だけ更新された瞬間に食い違い、しかも古い方も権威ある文面のままです。
 
-**`.claude/` 配下は、ここでは編集しません。** `npm install` が配置する場所で、次の `npm install` が変更を上書きします。hora の skill や agent の修正は [`hora-core`](https://github.com/openreachtech/hora-core)、それらの委譲先である手順の修正は [`hora-skills`](https://github.com/openreachtech/hora-skills) が置き場所です。どちらも英語のみ — 読み手が言語を選ぶ文書ではなく、Claude Code が読む文書だからです。従う文体は [`docs/writing-style.ja.md`](./docs/writing-style.ja.md) にあります。
+**`.claude/` 配下は、ここでは編集しません。** `npm install` が配置する場所で、次の `npm install` が変更を上書きします。hora の skill や agent の修正は [`hora-core`](https://github.com/openreachtech/hora-core)、それらの委譲先である手順の修正は、そのドメインのスキルパッケージ [`hora-skills-ort-core`](https://github.com/openreachtech/hora-skills-ort-core)・[`hora-skills-ort-renchan`](https://github.com/openreachtech/hora-skills-ort-renchan)・[`hora-skills-ort-furo`](https://github.com/openreachtech/hora-skills-ort-furo) が置き場所です。いずれも英語のみ — 読み手が言語を選ぶ文書ではなく、Claude Code が読む文書だからです。従う文体は [`docs/writing-style.ja.md`](./docs/writing-style.ja.md) にあります。
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ npm install
 
 Do this before writing `specs/` — once the repository holds commits of its own, discarding `.git` would take those with it too.
 
-**Either way, run `npm install` in the new repository before `/hora`. Without it there is no `/hora` to run.** This repository carries no skill and no agent of its own: `/hora` and the five skills it orders come from [`@openreachtech/hora`](https://github.com/openreachtech/hora-core), the procedures they delegate to from [`@openreachtech/hora-skills`](https://github.com/openreachtech/hora-skills), and a `postinstall` hook places both into `.claude/`. A fresh clone has an empty `.claude/` until that has run.
+**Either way, run `npm install` in the new repository before `/hora`. Without it there is no `/hora` to run.** This repository carries no skill and no agent of its own: `/hora` and the five skills it orders come from [`@openreachtech/hora`](https://github.com/openreachtech/hora-core), the procedures they delegate to from the three skills packages — [`-ort-core`](https://github.com/openreachtech/hora-skills-ort-core), [`-ort-renchan`](https://github.com/openreachtech/hora-skills-ort-renchan) and [`-ort-furo`](https://github.com/openreachtech/hora-skills-ort-furo) — and a `postinstall` hook places all of them into `.claude/`. A fresh clone has an empty `.claude/` until that has run.
 
 The third package, `@openreachtech/hora-ecosystem`, is the catalog checkpoint 5 checks before anything is written new. It is never placed anywhere — it is read where npm put it.
 
@@ -180,7 +180,7 @@ $EDITOR specs/1.1.0/request/csv-export.md   # what you want, in your own words
 
 The eighteen checkpoints are in [`checkpoints.md`](./.claude/skills/hora-build/references/checkpoints.md) — spec, use cases, DB and API schemas, stub API, supporting modules, real API, worker, security audit, then the frontend, then acceptance.
 
-**Hora Kit holds the order and the gates; it holds no procedure.** How to write a resolver, a migration, a component or a test — and what an acceptance review looks at — all come from [`@openreachtech/hora-skills`](https://github.com/openreachtech/hora-skills), equipped into this repository's own `.claude/skills/` by `npm install`. See [`docs/skills.md`](./docs/skills.md).
+**Hora Kit holds the order and the gates; it holds no procedure.** How to write a resolver, a migration, a component or a test — and what an acceptance review looks at — all come from the `@openreachtech/hora-skills-ort-*` packages — one per domain, equipped into this repository's own `.claude/skills/` by `npm install`. See [`docs/skills.md`](./docs/skills.md).
 
 ## Documentation
 
@@ -214,7 +214,7 @@ npm run lint
 
 **Every file under `docs/` is a pair — `x.md` and `x.ja.md`.** Change one and change the other in the same commit. Two documents saying the same thing will disagree the moment only one of them is updated, and the stale one still reads as authoritative.
 
-**Nothing under `.claude/` is edited here.** It is installed by `npm install`, and the next one overwrites whatever you changed. A fix to a hora skill or an agent belongs in [`hora-core`](https://github.com/openreachtech/hora-core), and one to a procedure they delegate to in [`hora-skills`](https://github.com/openreachtech/hora-skills) — both English only, since Claude Code reads them rather than a person choosing a language. [`docs/writing-style.md`](./docs/writing-style.md) is the style they are held to.
+**Nothing under `.claude/` is edited here.** It is installed by `npm install`, and the next one overwrites whatever you changed. A fix to a hora skill or an agent belongs in [`hora-core`](https://github.com/openreachtech/hora-core), and one to a procedure they delegate to in the skills package of its domain — [`hora-skills-ort-core`](https://github.com/openreachtech/hora-skills-ort-core), [`hora-skills-ort-renchan`](https://github.com/openreachtech/hora-skills-ort-renchan) or [`hora-skills-ort-furo`](https://github.com/openreachtech/hora-skills-ort-furo) — all English only, since Claude Code reads them rather than a person choosing a language. [`docs/writing-style.md`](./docs/writing-style.md) is the style they are held to.
 
 ## License
 


### PR DESCRIPTION
# Why

* Close #84

# How

* The three places that named `@openreachtech/hora-skills` now name the three packages the procedures come from, one per domain
* The line that says where a fix belongs points at the package of the domain in question, rather than at one repository that no longer holds any of them

`npm run lint:docs-pairs` reports 10 pairs, 0 failures.
