### PR TITLE
🔗 Use the source URL for every kit reference

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -100,7 +100,7 @@ cp specs/skeleton/spec.md specs/1.0.0/spec.md
 
 [`specs/skeleton/spec.md`](./specs/skeleton/spec.md) は見出しと表のヘッダだけの空の仕様書です。`specs/skeleton/` は版ではないので、`/hora` が版として読むことはありません。
 
-[`spec-format.md`](./.claude/skills/hora/references/spec-format.md) は書式の説明です。各節が何のためにあるか、どれが必須か、何があると `/hora` が止まって尋ねるかが書かれています。**説明はそちらを読み、埋めるのは前者**という分担です。
+[`spec-format.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/spec-format.md) は書式の説明です。各節が何のためにあるか、どれが必須か、何があると `/hora` が止まって尋ねるかが書かれています。**説明はそちらを読み、埋めるのは前者**という分担です。
 
 ### 3. `/hora` を実行する
 
@@ -144,11 +144,11 @@ cp specs/skeleton/spec.md specs/1.0.0/spec.md
 
 | SKILL | 役割 | 実行単位 |
 |---|---|---|
-| [`/hora-spec`](./.claude/skills/hora-spec/SKILL.md) | 既にあるものを読んだ上で、版の仕様書を対話しながら7つのステージで書く。1節ずつ承認を取って書き込む | 版ごとに1回 |
-| [`/hora-setup`](./.claude/skills/hora-setup/SKILL.md) | 仕様書が宣言したボイラープレートを取得し、案件用の値を埋め、実地に読む | 版ごとに1回 |
-| [`/hora-plan`](./.claude/skills/hora-plan/SKILL.md) | 版を確定し、対話しながら仕様を検証し、機能一覧を作る | 版ごとに1回 |
-| [`/hora-build`](./.claude/skills/hora-build/SKILL.md) | 1つの機能を18のチェックポイントで通す | 機能ごとに1回 |
-| [`/hora-accept`](./.claude/skills/hora-accept/SKILL.md) | その時点で実装済みの全機能に対して受入テストを実施する | 各機能の最終チェックポイント、および版全体の掃引 |
+| [`/hora-spec`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/SKILL.md) | 既にあるものを読んだ上で、版の仕様書を対話しながら7つのステージで書く。1節ずつ承認を取って書き込む | 版ごとに1回 |
+| [`/hora-setup`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-setup/SKILL.md) | 仕様書が宣言したボイラープレートを取得し、案件用の値を埋め、実地に読む | 版ごとに1回 |
+| [`/hora-plan`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-plan/SKILL.md) | 版を確定し、対話しながら仕様を検証し、機能一覧を作る | 版ごとに1回 |
+| [`/hora-build`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/SKILL.md) | 1つの機能を18のチェックポイントで通す | 機能ごとに1回 |
+| [`/hora-accept`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-accept/SKILL.md) | その時点で実装済みの全機能に対して受入テストを実施する | 各機能の最終チェックポイント、および版全体の掃引 |
 
 ```
 /hora-spec ─> /hora-setup ─> /hora-plan ──┬─> /hora-build 機能A ─> /hora-accept ─┐
@@ -156,7 +156,7 @@ cp specs/skeleton/spec.md specs/1.0.0/spec.md
                                           └─> /hora-build 機能C ─> /hora-accept ─┴─> 全体掃引 ─> merge
 ```
 
-ステージ0と7つの仕様ステージは [`stages.md`](./.claude/skills/hora-spec/references/stages.md) に、ステージ0が何を読んでよいかは [`investigation.md`](./.claude/skills/hora-spec/references/investigation.md) に、人への尋ね方は [`asking.md`](./.claude/skills/hora/references/asking.md) に、そこで適用される考え方 — ユースケースから始めること、1つの版に機能を詰め込みすぎないこと、ロールで切るかエンドポイントで切るか、同期処理か Worker か、認可を操作ごとに明記すること — は [`principles.md`](./.claude/skills/hora-spec/references/principles.md) にあります。
+ステージ0と7つの仕様ステージは [`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md) に、ステージ0が何を読んでよいかは [`investigation.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/investigation.md) に、人への尋ね方は [`asking.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/asking.md) に、そこで適用される考え方 — ユースケースから始めること、1つの版に機能を詰め込みすぎないこと、ロールで切るかエンドポイントで切るか、同期処理か Worker か、認可を操作ごとに明記すること — は [`principles.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/principles.md) にあります。
 
 ### 版を出した後に機能を足す
 
@@ -179,7 +179,7 @@ $EDITOR specs/1.1.0/request/csv-export.md   # 欲しいものを、自分の言�
 
 **その前に、そもそも新しい版が要るかを決めてください。** 境界は変更の大きさではなく、**その版がリリース済みかどうか**です。`git tag -l '1.0.0'` が空なら `specs/1.0.0/` を直接編集してよく、版番号も変わりません。リリース済みなら手を触れず、次の版を始めます。新しい版番号の決め方を含む手順全体は [`docs/commands.ja.md`](./docs/commands.ja.md) にあります。
 
-18のチェックポイントは [`checkpoints.md`](./.claude/skills/hora-build/references/checkpoints.md) にあります。仕様、想定ユースケース、DB / API スキーマ、stub API、実装に必要なモジュール、actual API、worker、セキュリティ検証、そしてフロントエンド、最後に検収です。
+18のチェックポイントは [`checkpoints.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/references/checkpoints.md) にあります。仕様、想定ユースケース、DB / API スキーマ、stub API、実装に必要なモジュール、actual API、worker、セキュリティ検証、そしてフロントエンド、最後に検収です。
 
 **Hora Kit が持つのは「順序」と「関所」だけで、「やり方」は持ちません。** resolver / migration / コンポーネント / テストの書き方も、受入レビューが何を見るかも、すべて `@openreachtech/hora-skills-ort-*` パッケージ（ドメインごとに1つ）にあります。`npm install` がこのリポジトリの `.claude/skills/` に配置します。詳しくは [`docs/skills.ja.md`](./docs/skills.ja.md) を参照してください。
 
@@ -194,7 +194,7 @@ $EDITOR specs/1.1.0/request/csv-export.md   # 欲しいものを、自分の言�
 | [`docs/stack/`](./docs/stack/README.ja.md) | **スタック・ハンドブック。** この boilerplate の技術スタックに固有のことすべて — origin カタログ、ミドルウェア、API 種別ごとの成果物 — を持ち、hora スキルが実行時に読む |
 | [`about-boilerplate.md`](./about-boilerplate.md) | **このテンプレート自身の版の記録** — プロジェクトがどの hora-boilerplate から始まったか。製品の版ではありません。製品の版は git タグが持ちます |
 
-規則そのものは、それを所有する skill 側にあります：[`hora/SKILL.md`](./.claude/skills/hora/SKILL.md)、[`structure.md`](./.claude/skills/hora/references/structure.md)、[`commits.md`](./.claude/skills/hora/references/commits.md)、[`done-criteria.md`](./.claude/skills/hora/references/done-criteria.md)、[`spec-format.md`](./.claude/skills/hora/references/spec-format.md)、[`stages.md`](./.claude/skills/hora-spec/references/stages.md)、[`principles.md`](./.claude/skills/hora-spec/references/principles.md)、[`checkpoints.md`](./.claude/skills/hora-build/references/checkpoints.md)。
+規則そのものは、それを所有する skill 側にあります：[`hora/SKILL.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/SKILL.md)、[`structure.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/structure.md)、[`commits.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/commits.md)、[`done-criteria.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/done-criteria.md)、[`spec-format.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/spec-format.md)、[`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md)、[`principles.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/principles.md)、[`checkpoints.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/references/checkpoints.md)。
 
 ## コントリビューション
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ cp specs/skeleton/spec.md specs/1.0.0/spec.md
 
 [`specs/skeleton/spec.md`](./specs/skeleton/spec.md) is the blank spec — headings and table headers only. `specs/skeleton/` is not a version, so `/hora` never reads it as one.
 
-[`spec-format.md`](./.claude/skills/hora/references/spec-format.md) explains the format: what each section is for, which ones are required, and what makes `/hora` stop and ask. **Read that one; fill in the other.**
+[`spec-format.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/spec-format.md) explains the format: what each section is for, which ones are required, and what makes `/hora` stop and ask. **Read that one; fill in the other.**
 
 ### 3. Run `/hora`
 
@@ -143,11 +143,11 @@ Then note the decision in `specs/<version>/spec.md`, so that everyone — and ev
 
 | Skill | Does | Runs |
 |---|---|---|
-| [`/hora-spec`](./.claude/skills/hora-spec/SKILL.md) | reads what already exists, then writes the version's spec with you through seven stages, one approved section at a time | once per version |
-| [`/hora-setup`](./.claude/skills/hora-setup/SKILL.md) | fetches the boilerplates the spec declares, fills in the project's values, reads the real tree | once per version |
-| [`/hora-plan`](./.claude/skills/hora-plan/SKILL.md) | fixes the version, verifies the spec with you in conversation, writes the feature list | once per version |
-| [`/hora-build`](./.claude/skills/hora-build/SKILL.md) | takes one feature through the eighteen checkpoints | once per feature |
-| [`/hora-accept`](./.claude/skills/hora-accept/SKILL.md) | runs acceptance over every feature implemented so far | at each feature's last checkpoint, and once as a whole-version sweep |
+| [`/hora-spec`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/SKILL.md) | reads what already exists, then writes the version's spec with you through seven stages, one approved section at a time | once per version |
+| [`/hora-setup`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-setup/SKILL.md) | fetches the boilerplates the spec declares, fills in the project's values, reads the real tree | once per version |
+| [`/hora-plan`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-plan/SKILL.md) | fixes the version, verifies the spec with you in conversation, writes the feature list | once per version |
+| [`/hora-build`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/SKILL.md) | takes one feature through the eighteen checkpoints | once per feature |
+| [`/hora-accept`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-accept/SKILL.md) | runs acceptance over every feature implemented so far | at each feature's last checkpoint, and once as a whole-version sweep |
 
 ```
 /hora-spec ─> /hora-setup ─> /hora-plan ──┬─> /hora-build #A ─> /hora-accept ─┐
@@ -155,7 +155,7 @@ Then note the decision in `specs/<version>/spec.md`, so that everyone — and ev
                                           └─> /hora-build #C ─> /hora-accept ─┴─> sweep ─> merge
 ```
 
-Stage 0 and the seven spec stages are in [`stages.md`](./.claude/skills/hora-spec/references/stages.md), what stage 0 may read in [`investigation.md`](./.claude/skills/hora-spec/references/investigation.md), how anything is put to you in [`asking.md`](./.claude/skills/hora/references/asking.md), and the thinking they apply — use cases first, a release that is not overloaded, roles or separate endpoints, synchronous work or a job, authorization stated per operation — in [`principles.md`](./.claude/skills/hora-spec/references/principles.md).
+Stage 0 and the seven spec stages are in [`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md), what stage 0 may read in [`investigation.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/investigation.md), how anything is put to you in [`asking.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/asking.md), and the thinking they apply — use cases first, a release that is not overloaded, roles or separate endpoints, synchronous work or a job, authorization stated per operation — in [`principles.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/principles.md).
 
 ### Adding a feature after a version has shipped
 
@@ -178,7 +178,7 @@ $EDITOR specs/1.1.0/request/csv-export.md   # what you want, in your own words
 
 **First decide whether you need a new version at all.** The line is not the size of the change but whether the version has been released — `git tag -l '1.0.0'` empty means you edit `specs/1.0.0/` and the number does not change. Once released, leave it alone and start the next one. [`docs/commands.md`](./docs/commands.md) has the whole procedure, including how the new number is chosen.
 
-The eighteen checkpoints are in [`checkpoints.md`](./.claude/skills/hora-build/references/checkpoints.md) — spec, use cases, DB and API schemas, stub API, supporting modules, real API, worker, security audit, then the frontend, then acceptance.
+The eighteen checkpoints are in [`checkpoints.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/references/checkpoints.md) — spec, use cases, DB and API schemas, stub API, supporting modules, real API, worker, security audit, then the frontend, then acceptance.
 
 **Hora Kit holds the order and the gates; it holds no procedure.** How to write a resolver, a migration, a component or a test — and what an acceptance review looks at — all come from the `@openreachtech/hora-skills-ort-*` packages — one per domain, equipped into this repository's own `.claude/skills/` by `npm install`. See [`docs/skills.md`](./docs/skills.md).
 
@@ -193,7 +193,7 @@ The eighteen checkpoints are in [`checkpoints.md`](./.claude/skills/hora-build/r
 | [`docs/stack/`](./docs/stack/README.md) | **the stack handbook.** Everything specific to this boilerplate's technology stack — the origin catalog, the middleware, what each API kind produces — read by the hora skills at run time |
 | [`about-boilerplate.md`](./about-boilerplate.md) | **the template's own version marker** — which hora-boilerplate this project started from. Not the product's version; that lives in git tags |
 
-The rules themselves live with the skill that owns each one: [`hora/SKILL.md`](./.claude/skills/hora/SKILL.md), [`structure.md`](./.claude/skills/hora/references/structure.md), [`commits.md`](./.claude/skills/hora/references/commits.md), [`done-criteria.md`](./.claude/skills/hora/references/done-criteria.md), [`spec-format.md`](./.claude/skills/hora/references/spec-format.md), [`stages.md`](./.claude/skills/hora-spec/references/stages.md), [`principles.md`](./.claude/skills/hora-spec/references/principles.md) and [`checkpoints.md`](./.claude/skills/hora-build/references/checkpoints.md).
+The rules themselves live with the skill that owns each one: [`hora/SKILL.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/SKILL.md), [`structure.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/structure.md), [`commits.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/commits.md), [`done-criteria.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/done-criteria.md), [`spec-format.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/spec-format.md), [`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md), [`principles.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/principles.md) and [`checkpoints.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/references/checkpoints.md).
 
 ## Contribution
 

--- a/docs/adopting.ja.md
+++ b/docs/adopting.ja.md
@@ -22,7 +22,7 @@ Hora Kit は通常「そこから始めるテンプレート」として出会�
 
 ## 最初に、2つの適用のどちらかを決める
 
-**以下のどの手順より先に、1つの問いに答えてください：仕様書とコードが食い違ったとき、どちらが正しいのか。** この文書の残り全部がその答えで分岐し、答えは仕様書の1行 — `Existing assets` 節の `Authority:` — に書かれます（[`spec-format.md`](../.claude/skills/hora/references/spec-format.md) の "Existing assets"）。
+**以下のどの手順より先に、1つの問いに答えてください：仕様書とコードが食い違ったとき、どちらが正しいのか。** この文書の残り全部がその答えで分岐し、答えは仕様書の1行 — `Existing assets` 節の `Authority:` — に書かれます（[`spec-format.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/spec-format.md) の "Existing assets"）。
 
 | | **`as-built`** — 実装が正 | **`to-spec`** — 仕様が正 |
 |---|---|---|
@@ -34,11 +34,11 @@ Hora Kit は通常「そこから始めるテンプレート」として出会�
 | 計画 | 全機能 `built:`、**1回の適用掃引**が全機能の関所18を閉じる | 未完了の機能ごとに関所が走り、既存コードを仕様へ**突き合わせて直す**（ゼロから作り直さない） |
 | その後 | 掃引通過 → merge → **タグ `1.0.0` — `Baseline: verified` なら、現状が検証されたベースラインとして固定される。** 新しい作業は `1.1.0` の差分として、`specs/1.1.0/request/` のメモから始まる | コードが仕様に届いたとき版が終わり、他の版と同じように検収される |
 
-**混在が普通で、機能ごとに宣言できます。** 15機能は完成、3機能は道半ば — `Existing assets` に `Authority: as-built` と書き、3機能に `<!-- authority: to-spec -->` を付けます（[`spec-format.md`](../.claude/skills/hora/references/spec-format.md) の "`authority`"）。ステージ1の機能ごとの確認でその3機能に「まだ終わっていない」と答えれば、手で編集しなくてもちょうどこの形になります。
+**混在が普通で、機能ごとに宣言できます。** 15機能は完成、3機能は道半ば — `Existing assets` に `Authority: as-built` と書き、3機能に `<!-- authority: to-spec -->` を付けます（[`spec-format.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/spec-format.md) の "`authority`"）。ステージ1の機能ごとの確認でその3機能に「まだ終わっていない」と答えれば、手で編集しなくてもちょうどこの形になります。
 
 **`as-built` が買わないもの：** 関所18は必ず走ります — 適用掃引こそが、固定されたベースラインを「主張された」ものではなく「検証された」ものにします。未認証で到達できるものは、宣言が何であれ1操作ずつ尋ねられます。そして宣言が届くのは、宣言した時点で作られていた機能だけです — `1.1.0` で足す機能は、他の新機能と同じく対話で仕様化されます。
 
-**もう1つ宣言があり、こちらは「どこまで検収してからタグを打つか」を決めます。** 同じ `Existing assets` 節の `Baseline:` 行で、値は2つです（[`spec-format.md`](../.claude/skills/hora/references/spec-format.md) の "Existing assets"）。
+**もう1つ宣言があり、こちらは「どこまで検収してからタグを打つか」を決めます。** 同じ `Existing assets` 節の `Baseline:` 行で、値は2つです（[`spec-format.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/spec-format.md) の "Existing assets"）。
 
 | | `verified` | `inventoried` |
 |---|---|---|
@@ -94,7 +94,7 @@ npm install
 
 **移動するか、新しく clone してください。シンボリックリンクは駄目です。** リンクされたリポジトリは、リポジトリ単位のコマンドがすべて依存している作業ディレクトリ規則を壊し、しかも壊れ方が間接的です — コマンドは走り、間違った設定を読み、もっともらしい結果を返します。
 
-**既存の `.git` には何もしません。** [`boilerplates.md`](../.claude/skills/hora-setup/references/boilerplates.md) にある `rm -rf .git && git init` は**boilerplate を新規 clone した場合**の手順で、他人のコミット数百件が製品リポジトリの `main` に着地しないためのものです。**既に存在したリポジトリはこれを丸ごと飛ばします** — キットはその上に**被せる**のであって、**上書きする**のではありません。
+**既存の `.git` には何もしません。** [`boilerplates.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-setup/references/handbook.md) にある `rm -rf .git && git init` は**boilerplate を新規 clone した場合**の手順で、他人のコミット数百件が製品リポジトリの `main` に着地しないためのものです。**既に存在したリポジトリはこれを丸ごと飛ばします** — キットはその上に**被せる**のであって、**上書きする**のではありません。
 
 ---
 
@@ -143,7 +143,7 @@ myproject-app/
 
 **実装リポジトリの中へリンクしないでください。** `legacy-api/docs/` は gitignore されているので、そこへのリンクは**あなたのディスクでは解決し、他の全員のクローンでは切れます** — しかも静かに切れます。必要なものは `specs/<version>/` 側にコピーしてください。
 
-**資料は1つの版の中に閉じ、版をまたいで共有しません**（[`structure.md`](../.claude/skills/hora/references/structure.md) の不変条件3）。1.1.0 で同じ文書が要るなら、そちらにコピーを置きます。冗長に見えますが意図的です — 共有すると、1.1.0 のために資料を直した瞬間に、1.0.0 が「当時とは違う資料」を指すことになります。
+**資料は1つの版の中に閉じ、版をまたいで共有しません**（[`structure.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/structure.md) の不変条件3）。1.1.0 で同じ文書が要るなら、そちらにコピーを置きます。冗長に見えますが意図的です — 共有すると、1.1.0 のために資料を直した瞬間に、1.0.0 が「当時とは違う資料」を指すことになります。
 
 ### このディレクトリが実際に決めていること
 
@@ -163,7 +163,7 @@ myproject-app/
 
 **迷ったら `annex/` へ。** 失われるものはありません — 内容が本当に必要なら、対話を通って仕様書に入り、そこから機能になります。遠回りの分だけ増えるのは「人が一度読んで是と言う」という一段で、それはまさに `sources/` が飛ばしている一段です。
 
-手で表を書き、どちらのディレクトリも使わない方法も使えます。書式は [`spec-format.md`](../.claude/skills/hora/references/spec-format.md) の "Directory layout" にあります。
+手で表を書き、どちらのディレクトリも使わない方法も使えます。書式は [`spec-format.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/spec-format.md) の "Directory layout" にあります。
 
 ### 持ち込めないものがあるとき
 
@@ -173,13 +173,13 @@ myproject-app/
 
 ## 手順3 — 「既にあるもの」として仕様書を書く
 
-**`/hora-spec` を実行してください。** ステージ0で既にあるものを読み、空の仕様書をコピーし、7つのステージ（[`stages.md`](../.claude/skills/hora-spec/references/stages.md)）を通して1節ずつあなたと書きます。手でコピーして埋める方法も使えます。同じ文書になります。
+**`/hora-spec` を実行してください。** ステージ0で既にあるものを読み、空の仕様書をコピーし、7つのステージ（[`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md)）を通して1節ずつあなたと書きます。手でコピーして埋める方法も使えます。同じ文書になります。
 
 ```sh
 cp specs/skeleton/spec.md specs/1.0.0/spec.md
 ```
 
-**製品を口述することは求められません。** 既存の20機能を記憶から、しかも厳密な書式で説明させれば、人は覚えているものだけを説明します。そして**語られなかった部分の沈黙は、「そこには何も無い」と全く同じに読めます。** そこでステージ0が、リポジトリと、あなたが指し示した文書を読み、そこに現れているものを草案に起こし、**書き上げるためではなく訂正するために**あなたへ返します（[`investigation.md`](../.claude/skills/hora-spec/references/investigation.md)）。
+**製品を口述することは求められません。** 既存の20機能を記憶から、しかも厳密な書式で説明させれば、人は覚えているものだけを説明します。そして**語られなかった部分の沈黙は、「そこには何も無い」と全く同じに読めます。** そこでステージ0が、リポジトリと、あなたが指し示した文書を読み、そこに現れているものを草案に起こし、**書き上げるためではなく訂正するために**あなたへ返します（[`investigation.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/investigation.md)）。
 
 **「読むもの」と「尋ねるもの」は別の一覧で、その線引きが設計の中心です。**
 
@@ -193,7 +193,7 @@ cp specs/skeleton/spec.md specs/1.0.0/spec.md
 
 **4行目が、既存プロジェクトへの適用が元を取る場所です。** 「サインインしていれば誰でも呼べる」は auth filter から読み取れる事実ですが、それが誰かの決定だったのかは、たいてい全く別の話だと判明します。
 
-**読んだものが、そのまま要件になることはありません。** 読み取りは確認として提示され（*「こう読み取りました。合っていますか」*）、あなたが是とするか訂正したものだけが書かれます。キット側の思いつきは提案として別に区別されるので、**提案が「システムが既にそうなっている」として文書に入ることはありません**（[`asking.md`](../.claude/skills/hora/references/asking.md)）。
+**読んだものが、そのまま要件になることはありません。** 読み取りは確認として提示され（*「こう読み取りました。合っていますか」*）、あなたが是とするか訂正したものだけが書かれます。キット側の思いつきは提案として別に区別されるので、**提案が「システムが既にそうなっている」として文書に入ることはありません**（[`asking.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/asking.md)）。
 
 **回答は、可能な限り選択肢として提示されます。** 保持期間の質問には現在の行数が、認可の質問には現在のフィルタが、`built:` の質問にはステージ0がその機能について見つけたものが添えられます。**書き起こすより、直すほうがはるかに多くなります。**
 
@@ -204,7 +204,7 @@ cp specs/skeleton/spec.md specs/1.0.0/spec.md
 | **1（想定ユースケース）** | 誰も書き残していない挙動が製品にはあります。ここでそれが言語化され、「実際の動き」と「本来望まれていたもの」の差が見えるようになります |
 | **6（セキュリティ）** | 呼び出し元が決められたことのない操作が、すでに動いています。現在のフィルタを読んで人の前に置けば、その全部が見つかります — 驚かれた1つ1つが「誰も決めていない認可」であり、それぞれが最初の検収掃引で確認される基準になります |
 
-各節の説明は [`spec-format.md`](../.claude/skills/hora/references/spec-format.md) にあります。適用時にはそのうち3つがいつも以上に重要です。
+各節の説明は [`spec-format.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/spec-format.md) にあります。適用時にはそのうち3つがいつも以上に重要です。
 
 ### 3.1 リポジトリ構成表に `Directory` 列
 
@@ -447,8 +447,8 @@ cp -r <hora-boilerplate>/docs/stack docs/stack
 | 各コマンドの詳細 | [`commands.ja.md`](./commands.ja.md) |
 | なぜこの設計なのか | [`architecture.ja.md`](./architecture.ja.md) |
 | 関所が委譲するスキル群 | [`skills.ja.md`](./skills.ja.md) |
-| 仕様書の書式 | [`spec-format.md`](../.claude/skills/hora/references/spec-format.md) |
-| ステージ0と、仕様書を書く7つのステージ | [`stages.md`](../.claude/skills/hora-spec/references/stages.md) |
-| ステージ0が何を読み、読んでも決まらないものは何か | [`investigation.md`](../.claude/skills/hora-spec/references/investigation.md) |
-| 「確認」と「提案」の違い | [`asking.md`](../.claude/skills/hora/references/asking.md) |
-| 18の関所 | [`checkpoints.md`](../.claude/skills/hora-build/references/checkpoints.md) |
+| 仕様書の書式 | [`spec-format.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/spec-format.md) |
+| ステージ0と、仕様書を書く7つのステージ | [`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md) |
+| ステージ0が何を読み、読んでも決まらないものは何か | [`investigation.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/investigation.md) |
+| 「確認」と「提案」の違い | [`asking.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/asking.md) |
+| 18の関所 | [`checkpoints.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/references/checkpoints.md) |

--- a/docs/adopting.md
+++ b/docs/adopting.md
@@ -22,7 +22,7 @@ After that, new features go through the full eighteen, one at a time.
 
 ## First, decide which of the two adoptions this is
 
-**Before any step below, answer one question: when the spec and the code disagree, which one is right?** Everything else in this document branches on the answer, and it is declared in one line of the spec — `Authority:`, in the `Existing assets` section ([`spec-format.md`](../.claude/skills/hora/references/spec-format.md), "Existing assets").
+**Before any step below, answer one question: when the spec and the code disagree, which one is right?** Everything else in this document branches on the answer, and it is declared in one line of the spec — `Authority:`, in the `Existing assets` section ([`spec-format.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/spec-format.md), "Existing assets").
 
 | | **`as-built`** — the implementation is the truth | **`to-spec`** — the spec is the truth |
 |---|---|---|
@@ -34,11 +34,11 @@ After that, new features go through the full eighteen, one at a time.
 | The plan | every feature `built:`, **one adoption sweep** closes checkpoint 18 for all of them | each unfinished feature runs its checkpoints, which **reconcile** existing code toward the spec rather than starting over |
 | Then | sweep passes → merge → **tag `1.0.0` — under `Baseline: verified`, the current state is now the fixed and verified baseline.** New work arrives as `1.1.0`, a diff, drafted from a note in `specs/1.1.0/request/` | the version finishes when the code reaches the spec, and is accepted like any other |
 
-**Mixing them is normal, and it is declared per feature.** Fifteen features are done and three are half-way: write `Authority: as-built` in `Existing assets` and put `<!-- authority: to-spec -->` on the three ([`spec-format.md`](../.claude/skills/hora/references/spec-format.md), "`authority`"). Answering `not finished` on those three during stage 1's per-feature confirmation produces exactly this shape without you editing anything by hand.
+**Mixing them is normal, and it is declared per feature.** Fifteen features are done and three are half-way: write `Authority: as-built` in `Existing assets` and put `<!-- authority: to-spec -->` on the three ([`spec-format.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/spec-format.md), "`authority`"). Answering `not finished` on those three during stage 1's per-feature confirmation produces exactly this shape without you editing anything by hand.
 
 **What `as-built` does not buy:** checkpoint 18 still runs — the adoption sweep is what makes the fixed baseline a verified one, not a claimed one. Anything reachable without authentication is still asked about one operation at a time, whatever the declaration says. And the declaration reaches only the features built when it was made — a feature added in `1.1.0` is specified in conversation like any other new feature.
 
-**There is a second declaration, and it decides how much is accepted before the tag.** It is the `Baseline:` line of the same `Existing assets` section, and it has two values ([`spec-format.md`](../.claude/skills/hora/references/spec-format.md), "Existing assets").
+**There is a second declaration, and it decides how much is accepted before the tag.** It is the `Baseline:` line of the same `Existing assets` section, and it has two values ([`spec-format.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/spec-format.md), "Existing assets").
 
 | | `verified` | `inventoried` |
 |---|---|---|
@@ -94,7 +94,7 @@ npm install
 
 **Move them, or clone them fresh — do not symlink.** A symlinked repository breaks the working-directory rule that every per-repository command depends on, and the failures are indirect: a command runs, reads the wrong config, and reports something plausible.
 
-**Nothing is done to their `.git`.** The `rm -rf .git && git init` you may read about in [`boilerplates.md`](../.claude/skills/hora-setup/references/boilerplates.md) belongs to a *fresh clone of a boilerplate*, so that hundreds of somebody else's commits never land on a product repository's `main`. **A repository that already existed skips that entirely** — the kit is adopted onto it, never over it.
+**Nothing is done to their `.git`.** The `rm -rf .git && git init` you may read about in [`boilerplates.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-setup/references/handbook.md) belongs to a *fresh clone of a boilerplate*, so that hundreds of somebody else's commits never land on a product repository's `main`. **A repository that already existed skips that entirely** — the kit is adopted onto it, never over it.
 
 ---
 
@@ -143,7 +143,7 @@ myproject-app/
 
 **Do not link into the implementation repositories.** `legacy-api/docs/` is gitignored, so a link into it **resolves on your disk and breaks in everybody else's clone** — and it breaks silently. Copy what you need into `specs/<version>/` instead.
 
-**Material is closed inside one version, not shared across them** ([`structure.md`](../.claude/skills/hora/references/structure.md), invariant 3). If 1.1.0 needs the same document, it gets its own copy. That looks redundant and is deliberate: shared material means editing it for 1.1.0 silently changes what 1.0.0 was written against.
+**Material is closed inside one version, not shared across them** ([`structure.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/structure.md), invariant 3). If 1.1.0 needs the same document, it gets its own copy. That looks redundant and is deliberate: shared material means editing it for 1.1.0 silently changes what 1.0.0 was written against.
 
 ### What the directories actually decide
 
@@ -163,7 +163,7 @@ The first two map onto two tables in `spec.md`, and **the difference is not fili
 
 **When in doubt, `annex/`.** Nothing is lost: if its content matters, it reaches the spec through the conversation and becomes a feature from there. All the longer route adds is one place where a person reads it and says yes — which is exactly what `sources/` skips.
 
-Writing the tables by hand and using neither directory works too — the format is in [`spec-format.md`](../.claude/skills/hora/references/spec-format.md), "Directory layout".
+Writing the tables by hand and using neither directory works too — the format is in [`spec-format.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/spec-format.md), "Directory layout".
 
 ### If you cannot bring something in
 
@@ -173,13 +173,13 @@ Writing the tables by hand and using neither directory works too — the format 
 
 ## Step 3 — Write the spec, describing what is already there
 
-**Run `/hora-spec`.** It reads what already exists at stage 0, copies the blank spec, and writes it with you a section at a time through its seven stages ([`stages.md`](../.claude/skills/hora-spec/references/stages.md)). Copying it and filling it in by hand still works and produces the same document:
+**Run `/hora-spec`.** It reads what already exists at stage 0, copies the blank spec, and writes it with you a section at a time through its seven stages ([`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md)). Copying it and filling it in by hand still works and produces the same document:
 
 ```sh
 cp specs/skeleton/spec.md specs/1.0.0/spec.md
 ```
 
-**You are not expected to dictate the product.** A person describing twenty existing features from memory, in an exacting format, describes the ones they remember — and the silence around the rest reads exactly like "there is nothing there". So stage 0 reads the repositories and every document you point it at, drafts what they show, and puts it back to you **to correct rather than to compose** ([`investigation.md`](../.claude/skills/hora-spec/references/investigation.md)).
+**You are not expected to dictate the product.** A person describing twenty existing features from memory, in an exacting format, describes the ones they remember — and the silence around the rest reads exactly like "there is nothing there". So stage 0 reads the repositories and every document you point it at, drafts what they show, and puts it back to you **to correct rather than to compose** ([`investigation.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/investigation.md)).
 
 **What it reads and what it asks are two different lists**, and the split is the whole design:
 
@@ -193,7 +193,7 @@ cp specs/skeleton/spec.md specs/1.0.0/spec.md
 
 **The fourth row is where adoption pays for itself.** "Anyone signed in can call this" is read off an auth filter; whether that was ever anybody's decision usually turns out to be a different question entirely.
 
-**Nothing it reads becomes a requirement on its own.** A reading is shown to you as a check — *"I read it as this; is that right?"* — and only what you confirm or correct is written. What the kit proposes is labelled a proposal, separately, so that a suggestion never enters the document as something the system already does ([`asking.md`](../.claude/skills/hora/references/asking.md)).
+**Nothing it reads becomes a requirement on its own.** A reading is shown to you as a check — *"I read it as this; is that right?"* — and only what you confirm or correct is written. What the kit proposes is labelled a proposal, separately, so that a suggestion never enters the document as something the system already does ([`asking.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/asking.md)).
 
 **Answers are offered as choices wherever they can be.** Existing row counts come with the retention question, current filters come with the authorization question, and what stage 0 found for a feature comes with the `built:` question. You correct far more than you compose.
 
@@ -204,7 +204,7 @@ Two stages earn their keep more here than anywhere else:
 | **1, use cases** | the product has behavior nobody ever wrote down. This is where it gets stated, and where the gap between what it does and what anybody wanted becomes visible |
 | **6, security** | an operation whose caller was never decided is already deployed. Reading the current filters and putting them in front of somebody finds every one — each surprise is an authorization nobody made, and each becomes a criterion the first acceptance sweep checks |
 
-[`spec-format.md`](../.claude/skills/hora/references/spec-format.md) explains every section. Three of them matter more than usual when adopting.
+[`spec-format.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/spec-format.md) explains every section. Three of them matter more than usual when adopting.
 
 ### 3.1 The repository layout, with a `Directory` column
 
@@ -451,8 +451,8 @@ Commit it like any other document. The handbook is versioned with your project's
 | what each command does, in detail | [`commands.md`](./commands.md) |
 | why the design is shaped this way | [`architecture.md`](./architecture.md) |
 | the skills the checkpoints delegate to | [`skills.md`](./skills.md) |
-| the format of a spec | [`spec-format.md`](../.claude/skills/hora/references/spec-format.md) |
-| stage 0, then the seven stages a spec is written through | [`stages.md`](../.claude/skills/hora-spec/references/stages.md) |
-| what stage 0 may read, and what no reading settles | [`investigation.md`](../.claude/skills/hora-spec/references/investigation.md) |
-| how a check differs from a proposal | [`asking.md`](../.claude/skills/hora/references/asking.md) |
-| the eighteen checkpoints | [`checkpoints.md`](../.claude/skills/hora-build/references/checkpoints.md) |
+| the format of a spec | [`spec-format.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/spec-format.md) |
+| stage 0, then the seven stages a spec is written through | [`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md) |
+| what stage 0 may read, and what no reading settles | [`investigation.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/investigation.md) |
+| how a check differs from a proposal | [`asking.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/asking.md) |
+| the eighteen checkpoints | [`checkpoints.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/references/checkpoints.md) |

--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -44,7 +44,7 @@ Hora Kit が仕様書をアプリケーションに変えるまで。何がど�
 
 **4つのどれも、このリポジトリの中にはありません。** 4層すべてがパッケージとして届き、このリポジトリが持つのは仕様書と、これらの文書と、`.hora/` にある実行自身の記録です。
 
-**驚かれるのは、パッケージ2つの間の分割です。** Hora Kit は GraphQL resolver や Sequelize migration や Vue コンポーネントの書き方を一切持っていません。持ってはいけません — それらは独自にバージョン管理・更新されるパッケージにあります。Hora Kit 側に写しを置けば、そのパッケージが動いた瞬間に食い違い、しかも**食い違ったことを誰も知らせません。** [`structure.md`](../.claude/skills/hora/references/structure.md) の "The division of labor" と [`skills.ja.md`](./skills.ja.md) を参照してください。
+**驚かれるのは、パッケージ2つの間の分割です。** Hora Kit は GraphQL resolver や Sequelize migration や Vue コンポーネントの書き方を一切持っていません。持ってはいけません — それらは独自にバージョン管理・更新されるパッケージにあります。Hora Kit 側に写しを置けば、そのパッケージが動いた瞬間に食い違い、しかも**食い違ったことを誰も知らせません。** [`structure.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/structure.md) の "The division of labor" と [`skills.ja.md`](./skills.ja.md) を参照してください。
 
 ---
 
@@ -65,9 +65,9 @@ Hora Kit が仕様書をアプリケーションに変えるまで。何がど�
 
 コストは実在し、承知の上で受け入れています。機能ごとにコンテナ群を立ち上げる手間は、間違ったテーブルの上に建てたその20機能を解きほぐす手間に比べれば安いためです。
 
-**退行の網が累積であることが、上の表の3行目を成立させています。** [`/hora-accept`](../.claude/skills/hora-accept/SKILL.md) はどの関所でも**ユニットスイートをリポジトリ全体に対して**流します。したがって、ある機能が過去の機能を壊した場合、壊したその実行で落ちます。高コストな側 — 実ブラウザで画面を駆動するレビュー — は関所ではその機能自身に絞られ、全機能を端から端まで駆動するのは版全体のスイープ（または明示的に要求した実行）の仕事です。
+**退行の網が累積であることが、上の表の3行目を成立させています。** [`/hora-accept`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-accept/SKILL.md) はどの関所でも**ユニットスイートをリポジトリ全体に対して**流します。したがって、ある機能が過去の機能を壊した場合、壊したその実行で落ちます。高コストな側 — 実ブラウザで画面を駆動するレビュー — は関所ではその機能自身に絞られ、全機能を端から端まで駆動するのは版全体のスイープ（または明示的に要求した実行）の仕事です。
 
-**この順序で作ることは、仕様に1つ条件を課します。見落としやすい条件です — 機能の受入基準は、その機能自身の関所で達成可能でなければなりません。** 後から作る機能を名指す基準は、それを読むどの関所でも満たせません。それでも4つの実行がその基準に対して動きます — 関所1は基準を読んで作り、6と16は基準ごとにテストを書き、18はその機能を落として他人の関所へ差し戻します。**そのため受入基準は二段になっています。** 機能ごとの基準は、その機能とその `depends` までが作られていて後は何も無い製品に対して確認されます。複数機能を跨ぐ振る舞いは仕様書の `Version acceptance criteria` 節へ行き、どの関所も読まず、版全体のスイープが確認します。段を間違えた基準は [`/hora-plan`](../.claude/skills/hora-plan/SKILL.md) で `forward-reference` として止まり、機能の順序を直すか、振る舞いの段を上げることで直します。同じ検査が、その裏側 — 書かれた順序が `depends` と矛盾している状態 — も捕まえます。
+**この順序で作ることは、仕様に1つ条件を課します。見落としやすい条件です — 機能の受入基準は、その機能自身の関所で達成可能でなければなりません。** 後から作る機能を名指す基準は、それを読むどの関所でも満たせません。それでも4つの実行がその基準に対して動きます — 関所1は基準を読んで作り、6と16は基準ごとにテストを書き、18はその機能を落として他人の関所へ差し戻します。**そのため受入基準は二段になっています。** 機能ごとの基準は、その機能とその `depends` までが作られていて後は何も無い製品に対して確認されます。複数機能を跨ぐ振る舞いは仕様書の `Version acceptance criteria` 節へ行き、どの関所も読まず、版全体のスイープが確認します。段を間違えた基準は [`/hora-plan`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-plan/SKILL.md) で `forward-reference` として止まり、機能の順序を直すか、振る舞いの段を上げることで直します。同じ検査が、その裏側 — 書かれた順序が `depends` と矛盾している状態 — も捕まえます。
 
 ---
 
@@ -87,7 +87,7 @@ Hora Kit が仕様書をアプリケーションに変えるまで。何がど�
 
 **`hora-verifier` が何も直さないのは意図的です。** 同じエージェントに実装と検証をさせると、落ちているテストを通るまで緩める道が開きます。このエージェントはファイル編集ツールを持たず、「落ちている」という事実を返すだけで、直しません。
 
-**`hora-implementer` は git にも `.hora/` にも `specs/` にも触れません。** 1関所ぶん — または1関所の1単位ぶん — のコードとテストを書き、それ以外はすべて報告します。必要な依存、触ってはいけない共有ファイル、メインセッションに集約ファイルを再生成させたいフォルダ、変えたくなった contract、仕様書で見つけた問題です。[`/hora-build`](../.claude/skills/hora-build/SKILL.md) がその報告に基づいて動きます。
+**`hora-implementer` は git にも `.hora/` にも `specs/` にも触れません。** 1関所ぶん — または1関所の1単位ぶん — のコードとテストを書き、それ以外はすべて報告します。必要な依存、触ってはいけない共有ファイル、メインセッションに集約ファイルを再生成させたいフォルダ、変えたくなった contract、仕様書で見つけた問題です。[`/hora-build`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/SKILL.md) がその報告に基づいて動きます。
 
 **`hora-digester` は1つのファイルだけを書き、他はすべて読むだけです。** 出力は `.hora/digests/<skill-name>.md` で、ヘッダには由来したパッケージと、そのパッケージのバージョンが入ります — だからダイジェストはインストール済みのバージョンと一致する間だけ使われ、由来したパッケージが更新されれば、そのダイジェストは次に読まれる前に書き直されます。権威はスキル本体のままです。ダイジェストで解けない疑問が出た時点で、implementer が本体を開きます。
 
@@ -157,7 +157,7 @@ Hora Kit が仕様書をアプリケーションに変えるまで。何がど�
 - [x] 7. Worker  <!-- n/a: this feature triggers no background job -->
 ```
 
-**状態は3つだけです**：未通過、通過、**理由付きの n/a**。理由の無い `n/a` は状態ではありません — 飛ばした関所が、通った関所の印を被っているだけです。全一覧と各関所の終了条件は [`checkpoints.md`](../.claude/skills/hora-build/references/checkpoints.md) にあります。
+**状態は3つだけです**：未通過、通過、**理由付きの n/a**。理由の無い `n/a` は状態ではありません — 飛ばした関所が、通った関所の印を被っているだけです。全一覧と各関所の終了条件は [`checkpoints.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/references/checkpoints.md) にあります。
 
 ---
 
@@ -182,7 +182,7 @@ Hora Kit が仕様書をアプリケーションに変えるまで。何がど�
 
 ## git モデル
 
-git 操作はすべてメインセッションで行われます — `/hora` 自身か、それが走らせた skill です。エージェントは決して git に触れません。規則は [`commits.md`](../.claude/skills/hora/references/commits.md) にあります。形はこうです。
+git 操作はすべてメインセッションで行われます — `/hora` 自身か、それが走らせた skill です。エージェントは決して git に触れません。規則は [`commits.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/commits.md) にあります。形はこうです。
 
 ![git モデル：main、release/&lt;version&gt;、そこから切られるブランチ](./images/git-model.ja.svg)
 
@@ -195,7 +195,7 @@ git 操作はすべてメインセッションで行われます — `/hora` 自
 
 **検収の後ではありません。** 検収（18）のスイートはその時点の全機能に及び、どの機能でも落ちうるので、待つとこの機能のブランチが他の機能の作業をまたいで開きっぱなしになります。検収が見つけたものは `retake/` ブランチで戻ってきます — 「マージ済みだが後から不足が判明した」の既存の名前が、まさにそれです。
 
-**関所17だけはこの表の外にあります。** ローカルの E2E 環境はバックエンド行にあり、その機能ブランチは8関所前（関所9）で既にマージ済みです。だからその変更は専用の `update/e2e-<what>-for-<feature-id>` ブランチに載り、他の `update/` と同じように切られてマージされます（[`commits.md`](../.claude/skills/hora/references/commits.md)）。
+**関所17だけはこの表の外にあります。** ローカルの E2E 環境はバックエンド行にあり、その機能ブランチは8関所前（関所9）で既にマージ済みです。だからその変更は専用の `update/e2e-<what>-for-<feature-id>` ブランチに載り、他の `update/` と同じように切られてマージされます（[`commits.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/commits.md)）。
 
 **依存が専用ブランチを持つ理由：** `package-lock.json` は2つの変更が同時にきれいに編集できないファイルです。「1度に1つ、次を始める前にマージ」が人間のチームが衝突を避ける方法であり、ここでも同じです。
 
@@ -217,7 +217,7 @@ git 操作はすべてメインセッションで行われます — `/hora` 自
 
 **そしてこの順序では、並列の価値自体が聞こえるほど大きくありません。** 単位は小さなタスクではなく、製品全体への検収で終わる1機能です。重ねられる余地はあまり残っていません。
 
-**関所の単位は、この問題の両側をどちらも回避します。だからこれだけが同時に走ります**（[`hora-build/SKILL.md`](../.claude/skills/hora-build/SKILL.md)）。単位はコミットより小さい — 関所6のどの単位も、そのゲートのただ1つのコミットに着地するので、後続の単位の成果が吸い込まれる先の先行コミットが存在しません。そして共有されるフォルダは、全単位が終わったあとにメインセッションが再生成するので、集約ファイルはどの単位も書きません。依存の場合は直列時の答えをそのまま保ちます — 必要になった単位はそれを報告し、`/hora-build` が専用ブランチで導入してから作業が続きます。
+**関所の単位は、この問題の両側をどちらも回避します。だからこれだけが同時に走ります**（[`hora-build/SKILL.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/SKILL.md)）。単位はコミットより小さい — 関所6のどの単位も、そのゲートのただ1つのコミットに着地するので、後続の単位の成果が吸い込まれる先の先行コミットが存在しません。そして共有されるフォルダは、全単位が終わったあとにメインセッションが再生成するので、集約ファイルはどの単位も書きません。依存の場合は直列時の答えをそのまま保ちます — 必要になった単位はそれを報告し、`/hora-build` が専用ブランチで導入してから作業が続きます。
 
 **効くのはウォールクロックよりも、各エージェントが抱える量です。** 1体で6つの resolver を書くエージェントは、6つ分に伸びたコンテキストを抱え、以降の全ターンでその全量を支払います。6体なら各自が1つ分だけを抱えます。実測では、build 中で最も重い単一エージェントは関所6のもので、最大の常駐コンテキストを抱えたまま308ターン回っていました。
 
@@ -229,7 +229,7 @@ git 操作はすべてメインセッションで行われます — `/hora` 自
 
 **すでに動いている製品では、口述はさらに悪化します。** たとえば20機能を持つ製品で、その全部を記憶から、しかもこの書式で説明させれば、人は覚えているものだけを話します。そして**語られなかった部分の沈黙は、「そこには何も無い」と全く同じに読めます。** **システムは「それが何をするか」の証人としては優秀で、「誰が何を望んだか」の証人としては役に立ちません。** 前者をステージ0が読み、後者のために7つのステージが残ります。
 
-**だから `/hora-spec` が書きます。そして、この半分にある機構はすべて、それが「AI が要件を決めた」にならないためにあります。** skill 自体の権威は [`hora-spec/SKILL.md`](../.claude/skills/hora-spec/SKILL.md)、ステージの権威は [`stages.md`](../.claude/skills/hora-spec/references/stages.md)、ステージ0が何を読んでよいかは [`investigation.md`](../.claude/skills/hora-spec/references/investigation.md)、人への尋ね方は [`asking.md`](../.claude/skills/hora/references/asking.md)、そこで適用される考え方は [`principles.md`](../.claude/skills/hora-spec/references/principles.md) にあります。
+**だから `/hora-spec` が書きます。そして、この半分にある機構はすべて、それが「AI が要件を決めた」にならないためにあります。** skill 自体の権威は [`hora-spec/SKILL.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/SKILL.md)、ステージの権威は [`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md)、ステージ0が何を読んでよいかは [`investigation.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/investigation.md)、人への尋ね方は [`asking.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/asking.md)、そこで適用される考え方は [`principles.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/principles.md) にあります。
 
 ---
 
@@ -254,7 +254,7 @@ git 操作はすべてメインセッションで行われます — `/hora` 自
 
 **読んでも決して決まらないのは意図です。** どの操作が在るかは事実ですが、それが誰のためか、本来誰が呼べるべきか、機能のどこまでが完成なのかは、ツリーの中には無い。これらは常に尋ねられます — 材料を並べた上で、何も推奨せずに。
 
-**唯一の切り分けは宣言で、それは書かれるものであって、推測されるものではありません。** `Authority: as-built` は、その意図を人が一度、仕様書の中で確定させたものです: 以後キットは `built:` を導出し、ユースケースを動いているシステムから草案して、草案値をデフォルトに機能ごとの訂正に出します。`to-spec` は逆向きに確定させます — 完成度は一切尋ねられず、全関所が現状のコードに対して走ります。宣言が書かれていないところでは、上の段落がそのまま全面的に適用されます（[`structure.md`](../.claude/skills/hora/references/structure.md) の不変条件2、"`Authority: as-built`"）。
+**唯一の切り分けは宣言で、それは書かれるものであって、推測されるものではありません。** `Authority: as-built` は、その意図を人が一度、仕様書の中で確定させたものです: 以後キットは `built:` を導出し、ユースケースを動いているシステムから草案して、草案値をデフォルトに機能ごとの訂正に出します。`to-spec` は逆向きに確定させます — 完成度は一切尋ねられず、全関所が現状のコードに対して走ります。宣言が書かれていないところでは、上の段落がそのまま全面的に適用されます（[`structure.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/structure.md) の不変条件2、"`Authority: as-built`"）。
 
 ---
 
@@ -274,7 +274,7 @@ git 操作はすべてメインセッションで行われます — `/hora` 自
 
 **後戻りは正常であり、失敗ではありません。** 手前のステージの誤りを見つけたステージは、それを述べ、戻り先のステージを名指し、実行はそこへ戻ります。ステージ7はまさにそのために存在し、不足をその場で継ぎ当てることはしません — その場での継ぎ当ては、「どのステージもデータモデルと突き合わせていないユースケース」が文書に残る道です。
 
-**同じ表が、実装側の指摘をここへ戻します。** 関所2 / 9 / 11 / 18 の指摘が、コードではなく仕様の不足だと判明した場合、見つかった場所で直すのではなく、それを所有するステージへ戻ります。どの指摘がどこへ戻るかは [`stages.md`](../.claude/skills/hora-spec/references/stages.md) の "What sends a run back into a stage" にあり、各ステージの終了条件と担当スキルも同じ文書にあります。
+**同じ表が、実装側の指摘をここへ戻します。** 関所2 / 9 / 11 / 18 の指摘が、コードではなく仕様の不足だと判明した場合、見つかった場所で直すのではなく、それを所有するステージへ戻ります。どの指摘がどこへ戻るかは [`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md) の "What sends a run back into a stage" にあり、各ステージの終了条件と担当スキルも同じ文書にあります。
 
 **あるステージが他のステージの節を書くことはありません。** ステージ4はユースケースを書かず、ステージ1は列の型を選びません。次のステージの節に手を伸ばしたステージは、それを決めるはずだった対話の前に、それを決めてしまっています。
 
@@ -329,13 +329,13 @@ git 操作はすべてメインセッションで行われます — `/hora` 自
 
 **その行を持つのはステージ5だけです** — フロントエンドのリポジトリを宣言しない版、たとえばスマートフォンアプリ向けの API のみの版です。他のステージはすべて通過します。認証が一切ない版でも、ステージ6でそのことと理由を述べる必要があり、バックエンド行の無い版でも、ステージ4でそれを宣言する必要があります。
 
-**2版目からは、ステージが「引き継ぎ」で通過することがあり、それも3状態のうちの「通過」です。** そこからの `spec.md` は差分なので、7つのステージが決めることの大半は前の版で決着しています。この版が触らない節を持つステージは、直前の版の答えを提示して確認を取り、引き継ぎを書き添えて通過します — `<!-- carried: 1.0.0's numbers, confirmed unchanged -->`。**推測ではなく確認です。** 引き継ぎは、走らなかったステージと見分けのつかない唯一の通過だからです。**ステージ6と7は、その版が足すものについては決して引き継ぎません。** それが、他を短く済ませてよい理由です。どのステージが引き継げるかは [`stages.md`](../.claude/skills/hora-spec/references/stages.md) にステージごとに書かれています。
+**2版目からは、ステージが「引き継ぎ」で通過することがあり、それも3状態のうちの「通過」です。** そこからの `spec.md` は差分なので、7つのステージが決めることの大半は前の版で決着しています。この版が触らない節を持つステージは、直前の版の答えを提示して確認を取り、引き継ぎを書き添えて通過します — `<!-- carried: 1.0.0's numbers, confirmed unchanged -->`。**推測ではなく確認です。** 引き継ぎは、走らなかったステージと見分けのつかない唯一の通過だからです。**ステージ6と7は、その版が足すものについては決して引き継ぎません。** それが、他を短く済ませてよい理由です。どのステージが引き継げるかは [`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md) にステージごとに書かれています。
 
 ---
 
 ## 両方を支える2つの境界
 
-上のすべては2本の線の上に載っています。どちらも [`structure.md`](../.claude/skills/hora/references/structure.md) に書かれています。
+上のすべては2本の線の上に載っています。どちらも [`structure.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/structure.md) に書かれています。
 
 ### 1. 所有権の分割
 
@@ -360,11 +360,11 @@ git 操作はすべてメインセッションで行われます — `/hora` 自
 | 各コマンドが何をしているか | [`commands.ja.md`](./commands.ja.md) |
 | 関所が委譲するスキル群 | [`skills.ja.md`](./skills.ja.md) |
 | 既存プロジェクトへの適用 | [`adopting.ja.md`](./adopting.ja.md) |
-| 18の関所そのもの | [`checkpoints.md`](../.claude/skills/hora-build/references/checkpoints.md) |
-| ステージ0と、仕様書を書く7つのステージ | [`stages.md`](../.claude/skills/hora-spec/references/stages.md) |
-| ステージ0が何を読み、読んでも決まらないものは何か | [`investigation.md`](../.claude/skills/hora-spec/references/investigation.md) |
-| 確認・提案・質問の違い | [`asking.md`](../.claude/skills/hora/references/asking.md) |
-| 仕様書を書くときの考え方 | [`principles.md`](../.claude/skills/hora-spec/references/principles.md) |
-| 仕様書の書式 | [`spec-format.md`](../.claude/skills/hora/references/spec-format.md) |
+| 18の関所そのもの | [`checkpoints.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/references/checkpoints.md) |
+| ステージ0と、仕様書を書く7つのステージ | [`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md) |
+| ステージ0が何を読み、読んでも決まらないものは何か | [`investigation.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/investigation.md) |
+| 確認・提案・質問の違い | [`asking.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/asking.md) |
+| 仕様書を書くときの考え方 | [`principles.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/principles.md) |
+| 仕様書の書式 | [`spec-format.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/spec-format.md) |
 
 <!-- ./images/ の図はペアで生成されています — x.svg と x.ja.svg。片方を直したら、もう片方も直してください -->

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,7 +44,7 @@ This document explains the design. It is not the authority on any rule — each 
 
 **Not one of the four is in this repository.** All four arrive as packages, and what this repository holds is the spec, these documents, and the run's own record under `.hora/`.
 
-**The split between the two packages is the one that surprises people.** Hora Kit contains no instructions for writing a GraphQL resolver, a Sequelize migration or a Vue component, and it must not — those live in a package that is versioned and updated on its own. A copy inside Hora Kit would disagree with the original the first time that package moved, and nothing would announce that it had. See [`structure.md`](../.claude/skills/hora/references/structure.md), "The division of labor", and [`skills.md`](./skills.md).
+**The split between the two packages is the one that surprises people.** Hora Kit contains no instructions for writing a GraphQL resolver, a Sequelize migration or a Vue component, and it must not — those live in a package that is versioned and updated on its own. A copy inside Hora Kit would disagree with the original the first time that package moved, and nothing would announce that it had. See [`structure.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/structure.md), "The division of labor", and [`skills.md`](./skills.md).
 
 ---
 
@@ -65,9 +65,9 @@ One feature goes through its spec, its backend, its frontend and then acceptance
 
 The cost is real and it is accepted deliberately: bringing a container stack up per feature is cheap next to unwinding those twenty features built on a wrong table.
 
-**The regression net is cumulative, which is what makes the middle row work.** At every gate, [`/hora-accept`](../.claude/skills/hora-accept/SKILL.md) runs the **unit suites across whole repositories** — so a feature that breaks an earlier one fails in the run that broke it. The expensive half, driving screens in a real browser, is scoped to the gate's own feature there; every feature is driven end to end once, at the whole-version sweep, or earlier on explicit request.
+**The regression net is cumulative, which is what makes the middle row work.** At every gate, [`/hora-accept`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-accept/SKILL.md) runs the **unit suites across whole repositories** — so a feature that breaks an earlier one fails in the run that broke it. The expensive half, driving screens in a real browser, is scoped to the gate's own feature there; every feature is driven end to end once, at the whole-version sweep, or earlier on explicit request.
 
-**Building in this order puts one requirement on the spec, and it is easy to miss: a feature's acceptance criteria have to be meetable at that feature's own gate.** A criterion naming a feature built later cannot be met at any gate that reads it — and four runs act on one anyway, because checkpoint 1 builds from the criteria, 6 and 16 write a test for each of them, and 18 fails the feature and sends the run into somebody else's checkpoint. **So acceptance criteria come in two tiers.** A feature's own are checked against a product in which that feature and its `depends` are built and nothing later is; a behavior spanning several features goes to the spec's `Version acceptance criteria` section, which no gate reads and the whole-version sweep checks. A criterion in the wrong tier is a `forward-reference` stop at [`/hora-plan`](../.claude/skills/hora-plan/SKILL.md), fixed by reordering the features or by moving the behavior up a tier — and the same check catches the other half of it, a written order that contradicts a `depends`.
+**Building in this order puts one requirement on the spec, and it is easy to miss: a feature's acceptance criteria have to be meetable at that feature's own gate.** A criterion naming a feature built later cannot be met at any gate that reads it — and four runs act on one anyway, because checkpoint 1 builds from the criteria, 6 and 16 write a test for each of them, and 18 fails the feature and sends the run into somebody else's checkpoint. **So acceptance criteria come in two tiers.** A feature's own are checked against a product in which that feature and its `depends` are built and nothing later is; a behavior spanning several features goes to the spec's `Version acceptance criteria` section, which no gate reads and the whole-version sweep checks. A criterion in the wrong tier is a `forward-reference` stop at [`/hora-plan`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-plan/SKILL.md), fixed by reordering the features or by moving the behavior up a tier — and the same check catches the other half of it, a written order that contradicts a `depends`.
 
 ---
 
@@ -87,7 +87,7 @@ Not everything can be delegated to a subagent, and the line is not about difficu
 
 **`hora-verifier` never fixes anything, and that is the point.** Letting the same agent implement and verify opens a path to loosening a failing test until it passes. It has no file-editing tools; it returns the fact that something is failing, and never fixes it.
 
-**`hora-implementer` never touches git, `.hora/`, or `specs/`.** It writes code and tests for one checkpoint — or for one unit of one — and reports everything else: a dependency it needs, a shared file it must not edit, the folder whose aggregation file the main session should regenerate, a contract it wanted to change, a problem it found in the spec. [`/hora-build`](../.claude/skills/hora-build/SKILL.md) acts on the report.
+**`hora-implementer` never touches git, `.hora/`, or `specs/`.** It writes code and tests for one checkpoint — or for one unit of one — and reports everything else: a dependency it needs, a shared file it must not edit, the folder whose aggregation file the main session should regenerate, a contract it wanted to change, a problem it found in the spec. [`/hora-build`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/SKILL.md) acts on the report.
 
 **`hora-digester` writes one file and reads everything else.** Its output is `.hora/digests/<skill-name>.md`, and the header names the package it was derived from and that package's version — so a digest is used only while it matches what is installed, and an update of the package it came from leaves each of its digests to be rewritten before any is read again. The skill itself stays the authority: an implementer opens it the moment its digest leaves a question open.
 
@@ -159,7 +159,7 @@ There is no state file. **The state is `.hora/`, and its checkboxes are the stat
 - [x] 7. Worker  <!-- n/a: this feature triggers no background job -->
 ```
 
-**Three states, and only three:** not passed, passed, and not-applicable-with-a-reason. A bare `n/a` is not a state — it is a skipped checkpoint wearing the mark of a cleared one. The full list, with each checkpoint's exit condition, is in [`checkpoints.md`](../.claude/skills/hora-build/references/checkpoints.md).
+**Three states, and only three:** not passed, passed, and not-applicable-with-a-reason. A bare `n/a` is not a state — it is a skipped checkpoint wearing the mark of a cleared one. The full list, with each checkpoint's exit condition, is in [`checkpoints.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/references/checkpoints.md).
 
 ---
 
@@ -184,7 +184,7 @@ Conflating the two costs one of those properties. Keeping them apart costs nothi
 
 ## The git model
 
-Every git operation happens in the main session — `/hora` itself, or a skill it runs. No agent any of them starts ever touches git. The rules are in [`commits.md`](../.claude/skills/hora/references/commits.md); the shape is this:
+Every git operation happens in the main session — `/hora` itself, or a skill it runs. No agent any of them starts ever touches git. The rules are in [`commits.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/commits.md); the shape is this:
 
 ![The git model: main, release/version, and the branches cut from it](./images/git-model.svg)
 
@@ -197,7 +197,7 @@ Every git operation happens in the main session — `/hora` itself, or a skill i
 
 **Not after acceptance** — acceptance (18) runs suites spanning every feature so far and can fail on any of them, so waiting for it would hold this feature's branches open across other features' work. What acceptance turns up comes back as a `retake/` branch instead, which is already the name for "merged, then found lacking".
 
-**Checkpoint 17 is the one that falls outside the table.** The local end-to-end environment lives in the backend row, whose feature branch merged eight checkpoints earlier — so its changes go on their own `update/e2e-<what>-for-<feature-id>` branch, cut and merged like any other `update/` ([`commits.md`](../.claude/skills/hora/references/commits.md)).
+**Checkpoint 17 is the one that falls outside the table.** The local end-to-end environment lives in the backend row, whose feature branch merged eight checkpoints earlier — so its changes go on their own `update/e2e-<what>-for-<feature-id>` branch, cut and merged like any other `update/` ([`commits.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/commits.md)).
 
 **Why a dependency gets its own branch:** `package-lock.json` is the file two changes cannot both edit cleanly. One change at a time, merged before the next starts, is how a human team avoids that conflict, and it is how this does too.
 
@@ -219,7 +219,7 @@ Giving each parallel task its own branch would fix it — except **a single work
 
 **The order also makes parallelism worth much less than it sounds.** The unit is not a small task; it is a feature that ends at an acceptance run over the whole product. There is not much left to overlap.
 
-**A checkpoint's units clear both halves of that problem, which is why they are the one thing that does run at once** ([`hora-build/SKILL.md`](../.claude/skills/hora-build/SKILL.md)). A unit is smaller than a commit: every unit of checkpoint 6 lands in the gate's single commit, so there is no earlier commit for a later unit's work to leak into. And the folder they share is regenerated by the main session once they have all finished, so no unit writes the aggregation file at all. The dependency case keeps its serial answer — a unit that needs one reports it, and `/hora-build` installs it on its own branch before the work continues.
+**A checkpoint's units clear both halves of that problem, which is why they are the one thing that does run at once** ([`hora-build/SKILL.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/SKILL.md)). A unit is smaller than a commit: every unit of checkpoint 6 lands in the gate's single commit, so there is no earlier commit for a later unit's work to leak into. And the folder they share is regenerated by the main session once they have all finished, so no unit writes the aggregation file at all. The dependency case keeps its serial answer — a unit that needs one reports it, and `/hora-build` installs it on its own branch before the work continues.
 
 **The saving is in what each agent carries, more than in the wall clock.** One agent writing six resolvers holds a context that grows across all six and pays for the whole of it on every later turn; six agents each hold one. On the measured run, the single heaviest agent was checkpoint 6's, at 308 turns against the largest resident context in the build.
 
@@ -231,7 +231,7 @@ Giving each parallel task its own branch would fix it — except **a single work
 
 **And on a project that already runs, dictation is worse still.** Asked to describe every existing feature — say twenty of them — from memory in that format, a person covers what they remember — and the silence around the rest reads exactly like "there is nothing there". **The system is the better witness for what it does, and no witness at all for what anybody wanted.** Stage 0 reads the first kind; the seven stages are still for the second.
 
-**So `/hora-spec` writes it — and every mechanism in this half exists to keep that from becoming "the AI decided the requirements".** [`hora-spec/SKILL.md`](../.claude/skills/hora-spec/SKILL.md) is the authority on the skill; [`stages.md`](../.claude/skills/hora-spec/references/stages.md) on the stages; [`investigation.md`](../.claude/skills/hora-spec/references/investigation.md) on what stage 0 may read; [`asking.md`](../.claude/skills/hora/references/asking.md) on how anything is put to a person; [`principles.md`](../.claude/skills/hora-spec/references/principles.md) on the thinking they apply.
+**So `/hora-spec` writes it — and every mechanism in this half exists to keep that from becoming "the AI decided the requirements".** [`hora-spec/SKILL.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/SKILL.md) is the authority on the skill; [`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md) on the stages; [`investigation.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/investigation.md) on what stage 0 may read; [`asking.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/asking.md) on how anything is put to a person; [`principles.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/principles.md) on the thinking they apply.
 
 ---
 
@@ -256,7 +256,7 @@ read the code and write the requirement it implies                     forbidden
 
 **What no reading ever settles is intent.** Which operations exist is a fact; who they are for, who *should* be allowed to call them, and how much of a feature counts as finished are not in the tree at all. Those are asked, always — with the evidence laid out and nothing recommended.
 
-**The one carve-out is a declaration — written, never inferred.** `Authority: as-built` is a person settling that intent once, in the spec: from there the kit derives `built:` and drafts the use cases off the running system, and puts each up for correction with the drafted value as the default. `to-spec` settles it the other way — completion is never asked, and every checkpoint runs against the code as it stands. Where no declaration is written, the paragraph above applies in full ([`structure.md`](../.claude/skills/hora/references/structure.md), invariant 2, "`Authority: as-built`").
+**The one carve-out is a declaration — written, never inferred.** `Authority: as-built` is a person settling that intent once, in the spec: from there the kit derives `built:` and drafts the use cases off the running system, and puts each up for correction with the drafted value as the default. `to-spec` settles it the other way — completion is never asked, and every checkpoint runs against the code as it stands. Where no declaration is written, the paragraph above applies in full ([`structure.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/structure.md), invariant 2, "`Authority: as-built`").
 
 ---
 
@@ -276,7 +276,7 @@ read the code and write the requirement it implies                     forbidden
 
 **Going back is normal, and it is not a failure.** A stage that turns up something an earlier one got wrong says so, names the stage, and the run returns there. Stage 7 exists to do exactly that, and it never patches a shortfall in place — patching in place is how a document ends up with a use case that no stage ever walked against a data model.
 
-**The same table is what brings a build finding back here.** A finding at checkpoint 2, 9, 11 or 18 that turns out to be a shortfall in the spec rather than in the code returns to the stage that owns it, instead of being fixed where it was found. Which finding returns where is in [`stages.md`](../.claude/skills/hora-spec/references/stages.md), "What sends a run back into a stage" — along with every stage's exit condition and the sub-skill that runs it.
+**The same table is what brings a build finding back here.** A finding at checkpoint 2, 9, 11 or 18 that turns out to be a shortfall in the spec rather than in the code returns to the stage that owns it, instead of being fixed where it was found. Which finding returns where is in [`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md), "What sends a run back into a stage" — along with every stage's exit condition and the sub-skill that runs it.
 
 **No stage may write another stage's section.** Stage 4 does not write use cases; stage 1 does not choose a column type. A stage that reaches into the next one's section has decided something before the conversation that was supposed to decide it.
 
@@ -331,13 +331,13 @@ read the code and write the requirement it implies                     forbidden
 
 **Only stage 5 has such a line at all** — a version that declares no frontend repository, an API-only release for a phone app, say. Every other stage is passed. A release with no authentication still has to say so at stage 6, and why; a version with no backend row still has to declare that at stage 4.
 
-**From the second version on, a stage may pass by carrying over, and that is still one of the three.** `spec.md` is a diff from there on, so most of what the seven stages settle was settled a release ago; a stage whose section this version does not touch states the previous version's answer, gets it confirmed, and passes with the carry-over written next to it — `<!-- carried: 1.0.0's numbers, confirmed unchanged -->`. **It is a check, never an assumption**, because a carry-over is the one kind of pass that is indistinguishable from a stage that did not run. **Stages 6 and 7 never carry over for anything a version adds**, which is what lets the rest be brief. Which stages may is per stage in [`stages.md`](../.claude/skills/hora-spec/references/stages.md).
+**From the second version on, a stage may pass by carrying over, and that is still one of the three.** `spec.md` is a diff from there on, so most of what the seven stages settle was settled a release ago; a stage whose section this version does not touch states the previous version's answer, gets it confirmed, and passes with the carry-over written next to it — `<!-- carried: 1.0.0's numbers, confirmed unchanged -->`. **It is a check, never an assumption**, because a carry-over is the one kind of pass that is indistinguishable from a stage that did not run. **Stages 6 and 7 never carry over for anything a version adds**, which is what lets the rest be brief. Which stages may is per stage in [`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md).
 
 ---
 
 ## The two boundaries that hold both halves together
 
-Everything above rests on two lines. Both are stated in [`structure.md`](../.claude/skills/hora/references/structure.md).
+Everything above rests on two lines. Both are stated in [`structure.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/structure.md).
 
 ### 1. Ownership is split
 
@@ -362,11 +362,11 @@ Everything above rests on two lines. Both are stated in [`structure.md`](../.cla
 | what each command does, step by step | [`commands.md`](./commands.md) |
 | the skills the checkpoints delegate to | [`skills.md`](./skills.md) |
 | putting this on a project that already exists | [`adopting.md`](./adopting.md) |
-| the eighteen checkpoints themselves | [`checkpoints.md`](../.claude/skills/hora-build/references/checkpoints.md) |
-| stage 0, then the seven stages a spec is written through | [`stages.md`](../.claude/skills/hora-spec/references/stages.md) |
-| what stage 0 may read, and what no reading settles | [`investigation.md`](../.claude/skills/hora-spec/references/investigation.md) |
-| a check, a proposal or a question | [`asking.md`](../.claude/skills/hora/references/asking.md) |
-| the thinking a spec is written with | [`principles.md`](../.claude/skills/hora-spec/references/principles.md) |
-| the format of a spec | [`spec-format.md`](../.claude/skills/hora/references/spec-format.md) |
+| the eighteen checkpoints themselves | [`checkpoints.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/references/checkpoints.md) |
+| stage 0, then the seven stages a spec is written through | [`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md) |
+| what stage 0 may read, and what no reading settles | [`investigation.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/investigation.md) |
+| a check, a proposal or a question | [`asking.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/asking.md) |
+| the thinking a spec is written with | [`principles.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/principles.md) |
+| the format of a spec | [`spec-format.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/spec-format.md) |
 
 <!-- The figures in ./images/ are generated in pairs — x.svg and x.ja.svg. Edit one and edit the other. -->

--- a/docs/commands.ja.md
+++ b/docs/commands.ja.md
@@ -82,17 +82,17 @@
 
 **ステージ1〜7はそれぞれが独立した skill で、単独でも叩けます**：`/hora-spec-usecases`、`/hora-spec-horizon`、`/hora-spec-nonfunctional`、`/hora-spec-backend`、`/hora-spec-frontend`、`/hora-spec-security`、`/hora-spec-review`。`/hora-spec` はこれらを順に走らせます。そのステージの対話だけやり直したいときに単独で叩いてください。ステージ0 だけは専用 skill を持たず、`/hora-spec` 自身が実行します。
 
-**順序は規則であり、各ステージは関所です。** ユースケースが固まる前に作った DB 設計は2回作ることになり、ユーザー数を知る前に設計したテーブルは間違った規模向けに設計されます。各ステージの通過条件は [`stages.md`](../.claude/skills/hora-spec/references/stages.md) にあります。
+**順序は規則であり、各ステージは関所です。** ユースケースが固まる前に作った DB 設計は2回作ることになり、ユーザー数を知る前に設計したテーブルは間違った規模向けに設計されます。各ステージの通過条件は [`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md) にあります。
 
 **後戻りは正常です。** ステージ7は、見つかった不足をそれを所有するステージへ戻すために存在します。チェックポイント2 / 9 / 11 / 18 が「コードではなく仕様の不足」を見つけたときも、同じ表に従ってここへ戻ります。
 
-**ステージ0 が、動いている製品を口述させずに済ませる仕組みです。** リポジトリと文書を読み、そこに現れているものを草案に起こし、あなたが訂正できる形で返します。読むものが何も無いプロジェクトでは、その旨を記録して次へ進みます（[`investigation.md`](../.claude/skills/hora-spec/references/investigation.md)）。
+**ステージ0 が、動いている製品を口述させずに済ませる仕組みです。** リポジトリと文書を読み、そこに現れているものを草案に起こし、あなたが訂正できる形で返します。読むものが何も無いプロジェクトでは、その旨を記録して次へ進みます（[`investigation.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/investigation.md)）。
 
 **コードのあるプロジェクトでは、1つの宣言がこの対話の量を決めます：`Authority:`** — `as-built`（今動いているものがこの版。質問は数個に減り、ユースケースはシステムから草案されてあなたが訂正する）か `to-spec`（仕様が正。コードが関所を通って追いつく）か。ステージ1で1回だけ尋ねられ、機能ごとに上書きでき、必須です — 手順の全体は [`adopting.ja.md`](./adopting.ja.md) の「最初に、2つの適用のどちらかを決める」にあります。
 
 ### 出した版に機能を足すとき
 
-**2版目からの `spec.md` は、直前の版に対する差分です** — この版が変える節だけを書きます。それ以外は「書かないこと」によって引き継がれ、過去の版は決して書き換えません（[`spec-format.md`](../.claude/skills/hora/references/spec-format.md)）。**空のスケルトンは差分の版にはコピーしません**。機能を1つ足すだけの文書に、空の見出しが20個並ぶことになるからです。
+**2版目からの `spec.md` は、直前の版に対する差分です** — この版が変える節だけを書きます。それ以外は「書かないこと」によって引き継がれ、過去の版は決して書き換えません（[`spec-format.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/spec-format.md)）。**空のスケルトンは差分の版にはコピーしません**。機能を1つ足すだけの文書に、空の見出しが20個並ぶことになるからです。
 
 **書くのは文書ではなく、概要で構いません。** 欲しいものを `specs/<version>/request/` に置いてください — メール、チケット、箇条書き1ページ、欲しいと言った本人の言葉のままで結構です。そして `/hora-spec` を実行します。ステージ0 がそれを最初に読み、**この版の議題**として扱い、7つのステージが節に起こします。各節は、書き込む前に全文を提示して承認を得ます。
 
@@ -114,11 +114,11 @@ specs/1.1.0/
 
 **ステージは、既に出したものへの同意を取り直しません。** この版が触らない節を持つステージは**引き継ぎ**として通過します — 直前の版の答えを、そこで確定した言葉のまま提示し、確認を取ります。**推測ではなく確認**であり、終了報告は引き継いだステージを1つずつ名指しします。引き継ぎは、走らなかった場合と見分けのつかない唯一の通過だからです。
 
-**2つのステージだけは決して引き継ぎません。そしてそれが、他を短く済ませてよい理由です。** ステージ6 は、この版が足す全操作の呼び出し元と拒否のされ方を、足した版で明記します。ステージ7 は差分ではなく**解決後の文書**をレビューします — 1.0.0 が書いた規則と矛盾する新操作は、2ページの差分の中では見えず、全体の中でははっきり見えるからです。どのステージが引き継げるかは [`stages.md`](../.claude/skills/hora-spec/references/stages.md) にステージごとに書かれています。
+**2つのステージだけは決して引き継ぎません。そしてそれが、他を短く済ませてよい理由です。** ステージ6 は、この版が足す全操作の呼び出し元と拒否のされ方を、足した版で明記します。ステージ7 は差分ではなく**解決後の文書**をレビューします — 1.0.0 が書いた規則と矛盾する新操作は、2ページの差分の中では見えず、全体の中でははっきり見えるからです。どのステージが引き継げるかは [`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md) にステージごとに書かれています。
 
 ### 尋ね方 — 確認・提案・質問
 
-**この3つは別のもので、同じ言い回しで出されることはありません**（[`asking.md`](../.claude/skills/hora/references/asking.md)）。
+**この3つは別のもので、同じ言い回しで出されることはありません**（[`asking.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/asking.md)）。
 
 | | 意味 | あなたが決めること |
 |---|---|---|
@@ -151,7 +151,7 @@ hora  ステージ1。「勤怠管理、承認、給与」と伺いました。
       どちらか追加しますか？
 ```
 
-**承認は「1節ごと」で、文書まるごとではありません。** 仕様書全体に対する1回の「はい」は、承認が無いよりも悪くなります — 記録の上では「読んだ」ことになるからです。理由は [`structure.md`](../.claude/skills/hora/references/structure.md) の不変条件1にあります。
+**承認は「1節ごと」で、文書まるごとではありません。** 仕様書全体に対する1回の「はい」は、承認が無いよりも悪くなります — 記録の上では「読んだ」ことになるからです。理由は [`structure.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/structure.md) の不変条件1にあります。
 
 ### 決してしないこと
 
@@ -314,7 +314,7 @@ contract に現れない変更（文言の修正、内部リファクタ）は p
 | **フロントエンド** | 10 フロント着手 · 11 UI/UX とユースケース · 12 コンポーネント設計 · 13 フロントのモジュール · 14 API クライアント · 15 UI · 16 データ取得の組み込み · 17 ローカルテスト環境 | frontend 行 | 17 の後 |
 | **検収** | 18 検収 | 無し | — |
 
-各関所の終了条件・委譲先スキル・n/a 条件は [`checkpoints.md`](../.claude/skills/hora-build/references/checkpoints.md) にあります。
+各関所の終了条件・委譲先スキル・n/a 条件は [`checkpoints.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/references/checkpoints.md) にあります。
 
 **順序について、意図して決めた点が3つあります。**
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -87,17 +87,17 @@ It reports the decision in one line before starting: *"continuing 1.0.0. 4 of 11
 
 **Each stage from 1 to 7 is its own skill, and each may be run directly**: `/hora-spec-usecases`, `/hora-spec-horizon`, `/hora-spec-nonfunctional`, `/hora-spec-backend`, `/hora-spec-frontend`, `/hora-spec-security`, `/hora-spec-review`. `/hora-spec` runs them in order; run one alone to redo just that stage's conversation. Stage 0 has no skill of its own — `/hora-spec` runs it itself.
 
-**The order is a rule, and each stage is a gate.** A data model designed before the use cases are fixed is designed twice; a table designed before the user counts are known is designed for the wrong number. Each stage's exit condition is in [`stages.md`](../.claude/skills/hora-spec/references/stages.md).
+**The order is a rule, and each stage is a gate.** A data model designed before the use cases are fixed is designed twice; a table designed before the user counts are known is designed for the wrong number. Each stage's exit condition is in [`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md).
 
 **Going back is normal.** Stage 7 exists to send the run back into whichever stage owns a shortfall — and so does checkpoint 2, 9, 11 or 18 when what it finds turns out to be the spec rather than the code.
 
-**Stage 0 is what stops a running product from having to be dictated.** It reads the repositories and the documents, drafts what they show, and hands it back for you to correct. On a project with nothing to read it records that and moves on ([`investigation.md`](../.claude/skills/hora-spec/references/investigation.md)).
+**Stage 0 is what stops a running product from having to be dictated.** It reads the repositories and the documents, drafts what they show, and hands it back for you to correct. On a project with nothing to read it records that and moves on ([`investigation.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/investigation.md)).
 
 **On a project with code, one declaration decides how much of that conversation you get: `Authority:`** — `as-built` (what runs is what this version is; questions drop to a handful, and use cases are drafted from the system for you to correct) or `to-spec` (the spec is the truth; the code catches up through the checkpoints). It is asked once at stage 1, overridable per feature, and required — the whole procedure is in [`adopting.md`](./adopting.md), "First, decide which of the two adoptions this is".
 
 ### Adding a feature to a version that already shipped
 
-**From the second version on, `spec.md` is a diff against the version before it** — only the sections this version changes. Everything else carries over by being absent, and past versions are never rewritten ([`spec-format.md`](../.claude/skills/hora/references/spec-format.md), "From the second version on"). **The blank spec is not copied into a diff version**: it would land twenty empty headings in a document that needed one new feature.
+**From the second version on, `spec.md` is a diff against the version before it** — only the sections this version changes. Everything else carries over by being absent, and past versions are never rewritten ([`spec-format.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/spec-format.md), "From the second version on"). **The blank spec is not copied into a diff version**: it would land twenty empty headings in a document that needed one new feature.
 
 **Write the outline, not the document.** Drop what you want into `specs/<version>/request/` — a mail, a ticket, a page of bullets, in your own words, written by whoever wanted it — and run `/hora-spec`. Stage 0 reads it first and treats it as this version's agenda; the seven stages turn it into sections, each one shown to you in full before it is written.
 
@@ -119,11 +119,11 @@ specs/1.1.0/
 
 **The stages do not make you re-agree to what shipped.** A stage whose section this version does not touch passes as a **carry-over** — the previous version's answer, stated back to you in the words it was fixed in, and confirmed. It is checked, never assumed, and the closing report names every one, because a carry-over is the one kind of pass that looks the same as not having run.
 
-**Two stages never carry over, and they are why the rest may be brief.** Stage 6 states the caller and the refusal of every operation this version adds, at the version that adds it; stage 7 reviews the **resolved** document rather than the diff — a new operation contradicting a rule 1.0.0 wrote is invisible in two pages and plain in the whole. Which stages may carry over is per stage in [`stages.md`](../.claude/skills/hora-spec/references/stages.md).
+**Two stages never carry over, and they are why the rest may be brief.** Stage 6 states the caller and the refusal of every operation this version adds, at the version that adds it; stage 7 reviews the **resolved** document rather than the diff — a new operation contradicting a rule 1.0.0 wrote is invisible in two pages and plain in the whole. Which stages may carry over is per stage in [`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md).
 
 ### How it asks: a check, a proposal, a question
 
-**These are three different things and they are never phrased alike** ([`asking.md`](../.claude/skills/hora/references/asking.md)).
+**These are three different things and they are never phrased alike** ([`asking.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/asking.md)).
 
 | | What it means | What you are deciding |
 |---|---|---|
@@ -156,7 +156,7 @@ hora  Stage 1. You described "attendance management, approval, payroll".
       Add either?
 ```
 
-**Approval is per section, never per document.** One "yes" over a whole spec is worse than none, because the record then says it was read. The reasoning is in [`structure.md`](../.claude/skills/hora/references/structure.md), invariant 1.
+**Approval is per section, never per document.** One "yes" over a whole spec is worse than none, because the record then says it was read. The reasoning is in [`structure.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/structure.md), invariant 1.
 
 ### What it never does
 
@@ -319,7 +319,7 @@ It reports in one line before starting: *"building #attendance, from checkpoint 
 | **Frontend** | 10 open the frontend · 11 UI/UX and use cases · 12 component design · 13 frontend modules · 14 API client · 15 UI · 16 wire the data in · 17 local test environment | a frontend row | 17 |
 | **Acceptance** | 18 acceptance | nothing | — |
 
-Each one's exit condition, delegate skill and not-applicable rule is in [`checkpoints.md`](../.claude/skills/hora-build/references/checkpoints.md).
+Each one's exit condition, delegate skill and not-applicable rule is in [`checkpoints.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/references/checkpoints.md).
 
 **Three things about the order are deliberate:**
 

--- a/docs/skills.ja.md
+++ b/docs/skills.ja.md
@@ -67,13 +67,13 @@ node_modules/@openreachtech/hora-skills-ort-furo/dist/skills/<skill>/     ─>  
 - **リポジトリの clone を待ちません。** 4つのパッケージはいずれもこのリポジトリ自身の devDependencies なので、ここで `npm install` が済んでいれば使えます
 - **コピーは gitignore 済みで、ルートの lint からも除外されています。** どちらも `.claude/agents/` と `.claude/skills/` の全体を無視した上で、このリポジトリ自身のものを1つずつ名指しで戻す形です。名前パターンではなく許可リストなのは後述の理由によります。生成物であって、ここで書いたものではありません
 
-**配置されるのはこの4つで、もう1つは置かれた場所のまま読まれます。** **`@openreachtech/hora-ecosystem`** — 同じくこのリポジトリの devDependency で、関所5が「新しく書く前に」確認する社内パッケージのカタログです。どこにも配置されず、`node_modules/` の中でそのまま読まれます。レイアウトはパッケージ自身が自由に変えるものです（[`checkpoints.md`](../.claude/skills/hora-build/references/checkpoints.md) の関所5）。
+**配置されるのはこの4つで、もう1つは置かれた場所のまま読まれます。** **`@openreachtech/hora-ecosystem`** — 同じくこのリポジトリの devDependency で、関所5が「新しく書く前に」確認する社内パッケージのカタログです。どこにも配置されず、`node_modules/` の中でそのまま読まれます。レイアウトはパッケージ自身が自由に変えるものです（[`checkpoints.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/references/checkpoints.md) の関所5）。
 
 ---
 
 ## hora のファイルは、これらのスキル名を書きません
 
-[`checkpoints.md`](../.claude/skills/hora-build/references/checkpoints.md) も、[`stages.md`](../.claude/skills/hora-spec/references/stages.md) も、エージェント定義も、このページも書きません。**スキル名はパッケージのものであり、パッケージはそれを自由に変えられます** — そして書き留められた名前は、**静かに壊れる唯一の種類の写し**です。
+[`checkpoints.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/references/checkpoints.md) も、[`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md) も、エージェント定義も、このページも書きません。**スキル名はパッケージのものであり、パッケージはそれを自由に変えられます** — そして書き留められた名前は、**静かに壊れる唯一の種類の写し**です。
 
 ```
 パッケージがスキルを改名する
@@ -111,13 +111,13 @@ Hora Kit    「<かつての名前> に委譲せよ」
 
 ### エージェントに届くのはスキル本体ではなく、そのダイジェストです
 
-**マッチしたスキルは数千行に及び、それを読むエージェントのターン全部で常駐し続けます。** 関所のコストは常駐サイズとターン数の積に近いので、`/hora-build` が implementer に渡すのは `.hora/digests/<skill-name>.md` — 同じ規約を短くしたもので、マッチしたスキルにインストール済みバージョンのダイジェストが無ければ、そのとき [`hora-digester`](../.claude/agents/hora-digester.md) が書きます。上の記録が名前と並べて由来バージョンを残しているのは、そのためです。
+**マッチしたスキルは数千行に及び、それを読むエージェントのターン全部で常駐し続けます。** 関所のコストは常駐サイズとターン数の積に近いので、`/hora-build` が implementer に渡すのは `.hora/digests/<skill-name>.md` — 同じ規約を短くしたもので、マッチしたスキルにインストール済みバージョンのダイジェストが無ければ、そのとき [`hora-digester`](https://github.com/openreachtech/hora-core/blob/main/kit/agents/hora-digester.md) が書きます。上の記録が名前と並べて由来バージョンを残しているのは、そのためです。
 
 **ダイジェストは写しであり、このページ冒頭の規則が認める唯一の写しです。** 写しが危険なのは、静かに古びるからです。ダイジェストは由来したパッケージバージョンを自分のヘッダに持つので、そのバージョンがインストールされている間しか読まれず、パッケージが更新されれば、次に読まれる前に全部が書き直されます。エージェントの常駐量を減らすだけで、何も決めません。
 
 **両者が食い違ったとき決めるのは、スキル本体の文面です。** ダイジェストは出典ファイルを名指ししていて、疑問が残った時点でエージェントはそのファイルを開きます — 記述が薄いとき、そこを見ろと書かれているとき、これから書くものがダイジェストの説明そのものだと言い切れないとき。だから短く書きすぎた規約のコストは「1回の読み込み」であって、規約が失われることではありません。
 
-**スキルそのものが合否基準である工程は、この経路を通りません。** 関所8のセキュリティ監査と検収レビューはスキルを丸ごと invoke します。コードを書くエージェントには「短い版では足りない」と気づく瞬間がありますが、監査にはそれが無いからです — 抜けている検査は、誰も尋ねようと思いつかない検査です。**要約された検査リストは短い検査リストであり、そして合格を報告します。**（[`structure.md`](../.claude/skills/hora/references/structure.md)「How the match is made」）
+**スキルそのものが合否基準である工程は、この経路を通りません。** 関所8のセキュリティ監査と検収レビューはスキルを丸ごと invoke します。コードを書くエージェントには「短い版では足りない」と気づく瞬間がありますが、監査にはそれが無いからです — 抜けている検査は、誰も尋ねようと思いつかない検査です。**要約された検査リストは短い検査リストであり、そして合格を報告します。**（[`structure.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/structure.md)「How the match is made」）
 
 ### 名前のうち読む価値があるのは接頭辞だけです
 
@@ -145,7 +145,7 @@ Hora Kit    「<かつての名前> に委譲せよ」
 ls .claude/skills/
 ```
 
-そして「関所 → 委譲するスキル」の権威ある対応は [`checkpoints.md`](../.claude/skills/hora-build/references/checkpoints.md)、「仕様ステージ → 委譲するスキル」は [`stages.md`](../.claude/skills/hora-spec/references/stages.md) です。**どちらも意図的にここには再掲しません** — あの表の2つ目の写しは、まさにこのドキュメント全体が扱っている食い違いそのものになります。
+そして「関所 → 委譲するスキル」の権威ある対応は [`checkpoints.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/references/checkpoints.md)、「仕様ステージ → 委譲するスキル」は [`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md) です。**どちらも意図的にここには再掲しません** — あの表の2つ目の写しは、まさにこのドキュメント全体が扱っている食い違いそのものになります。
 
 ### `hor-` — バックエンド（renchan）
 
@@ -223,7 +223,7 @@ description で突き合わせることは、改名の問題を消しますが�
 
 | | |
 |---|---|
-| 各関所が何の作業を委譲するかの権威 | [`checkpoints.md`](../.claude/skills/hora-build/references/checkpoints.md) |
-| 境界の規則としての記述 | [`structure.md`](../.claude/skills/hora/references/structure.md) の "The division of labor" と "No hora file ever names one of those skills" |
+| 各関所が何の作業を委譲するかの権威 | [`checkpoints.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/references/checkpoints.md) |
+| 境界の規則としての記述 | [`structure.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/structure.md) の "The division of labor" と "No hora file ever names one of those skills" |
 | なぜこの設計なのか | [`architecture.ja.md`](./architecture.ja.md) |
 | 各コマンドが何をしているか | [`commands.ja.md`](./commands.ja.md) |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -67,13 +67,13 @@ node_modules/@openreachtech/hora-skills-ort-furo/dist/skills/<skill>/     ─>  
 - **It does not wait for any repository to be cloned.** All four packages are this repository's own devDependencies, so they are ready as soon as `npm install` has run here
 - **The copies are gitignored, and excluded from the root lint.** Both do it by ignoring the whole of `.claude/agents/` and `.claude/skills/` and naming this repository's own entries back in, one by one — an allowlist, not a name pattern, for the reason below. They are regenerated, not authored here
 
-**Those four are equipped. One more package is read where it lies:** **`@openreachtech/hora-ecosystem`** — also a devDependency here — the catalog of in-house packages that checkpoint 5 checks before anything is written new. It is never equipped anywhere: it is read in place under `node_modules/`, and its layout is its own to change ([`checkpoints.md`](../.claude/skills/hora-build/references/checkpoints.md), checkpoint 5).
+**Those four are equipped. One more package is read where it lies:** **`@openreachtech/hora-ecosystem`** — also a devDependency here — the catalog of in-house packages that checkpoint 5 checks before anything is written new. It is never equipped anywhere: it is read in place under `node_modules/`, and its layout is its own to change ([`checkpoints.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/references/checkpoints.md), checkpoint 5).
 
 ---
 
 ## No hora file names one of these skills
 
-Not [`checkpoints.md`](../.claude/skills/hora-build/references/checkpoints.md), not [`stages.md`](../.claude/skills/hora-spec/references/stages.md), not an agent definition, not this page. **A skill's name belongs to the package, which is free to change it** — and a written-down name is the one kind of copy that fails silently.
+Not [`checkpoints.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/references/checkpoints.md), not [`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md), not an agent definition, not this page. **A skill's name belongs to the package, which is free to change it** — and a written-down name is the one kind of copy that fails silently.
 
 ```
 the package renames a skill
@@ -111,13 +111,13 @@ The main session is handed the equipped skills' descriptions as part of its own 
 
 ### What reaches the agent is a digest, not the skill
 
-**A matched skill runs to thousands of lines, and it stays resident for every turn the agent reading it takes.** A checkpoint's cost is close to that resident size multiplied by its turn count, so what `/hora-build` hands an implementer is `.hora/digests/<skill-name>.md` — the same conventions in short form, written by [`hora-digester`](../.claude/agents/hora-digester.md) the first time a matched skill has no digest at the installed package version. That is also why the record above names the version the digests came from, beside the names themselves.
+**A matched skill runs to thousands of lines, and it stays resident for every turn the agent reading it takes.** A checkpoint's cost is close to that resident size multiplied by its turn count, so what `/hora-build` hands an implementer is `.hora/digests/<skill-name>.md` — the same conventions in short form, written by [`hora-digester`](https://github.com/openreachtech/hora-core/blob/main/kit/agents/hora-digester.md) the first time a matched skill has no digest at the installed package version. That is also why the record above names the version the digests came from, beside the names themselves.
 
 **A digest is a copy, and it is the one copy the rule this page opens with admits.** What makes a copy dangerous is that it goes stale in silence. A digest carries the package version it was derived from in its own header, so it is read only while that version is installed — and a package update leaves every digest to be rewritten before any of them is read again. It reduces what an agent holds resident, and it decides nothing.
 
 **When the two disagree, the skill's own text is what settles it.** A digest names the file it came from, and the agent opens that file the moment a question stays open — where the digest is thin, where it points there, or where the work is not obviously the thing it describes. So a convention a digest states too briefly costs one read; it is not a convention lost.
 
-**Nothing whose skill *is* the criteria is read this way.** The security audit at checkpoint 8 and the acceptance review invoke their skills whole, because an agent writing code has a moment where the short form announces its own gap and an audit does not: the missing check is the one nobody thinks to ask about. **A summarized check list is a shorter check list, and it reports a pass.** ([`structure.md`](../.claude/skills/hora/references/structure.md), "How the match is made")
+**Nothing whose skill *is* the criteria is read this way.** The security audit at checkpoint 8 and the acceptance review invoke their skills whole, because an agent writing code has a moment where the short form announces its own gap and an audit does not: the missing check is the one nobody thinks to ask about. **A summarized check list is a shorter check list, and it reports a pass.** ([`structure.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/structure.md), "How the match is made")
 
 ### The prefix is the one part of a name worth reading
 
@@ -145,7 +145,7 @@ This is also why the exclusion lists above are allowlists rather than `hor-*`/`h
 ls .claude/skills/
 ```
 
-And the authoritative statement of **what work** each checkpoint delegates is [`checkpoints.md`](../.claude/skills/hora-build/references/checkpoints.md); for a spec stage it is [`stages.md`](../.claude/skills/hora-spec/references/stages.md). **Neither is repeated here, deliberately** — a second copy of either would be exactly the drift this whole document is about.
+And the authoritative statement of **what work** each checkpoint delegates is [`checkpoints.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/references/checkpoints.md); for a spec stage it is [`stages.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-spec/references/stages.md). **Neither is repeated here, deliberately** — a second copy of either would be exactly the drift this whole document is about.
 
 ### `hor-` — backend (renchan)
 
@@ -223,7 +223,7 @@ Matching against descriptions removes the rename problem, not the *dropped* one.
 
 | | |
 |---|---|
-| the authoritative statement of what work each checkpoint delegates | [`checkpoints.md`](../.claude/skills/hora-build/references/checkpoints.md) |
-| the boundary, stated as a rule | [`structure.md`](../.claude/skills/hora/references/structure.md), "The division of labor" and "No hora file ever names one of those skills" |
+| the authoritative statement of what work each checkpoint delegates | [`checkpoints.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora-build/references/checkpoints.md) |
+| the boundary, stated as a rule | [`structure.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/structure.md), "The division of labor" and "No hora file ever names one of those skills" |
 | why the design is shaped this way | [`architecture.md`](./architecture.md) |
 | what each command does | [`commands.md`](./commands.md) |


### PR DESCRIPTION
# Why

* Close #90

# How

* **146 links resolved to nothing.** Every reference to a kit file was written as a relative path into `.claude/`, which `npm install` places and `.gitignore` excludes — so on GitHub each one is a 404, and in a fresh clone the file is absent until the hook has run. They now name the source in `hora-core`, which resolves wherever the document is read
* One of them was doubly broken: `hora-setup/references/boilerplates.md` was renamed to `handbook.md` in `hora-core`, and a relative link into a directory nobody had could never say so
* No document under `docs/` or either README now holds a relative link that does not resolve — 0 left, verified against the working tree, and all 17 targets checked against `hora-core` on `main`
* `npm run lint:docs-pairs` reports 10 pairs, 0 failures
