### PR TITLE
📄 Update the package count the documents state

### DIFF
--- a/docs/adopting.ja.md
+++ b/docs/adopting.ja.md
@@ -303,7 +303,7 @@ Authority: as-built — what these repositories do is what 1.0.0 is
 | `package.json` の name/description | **プレースホルダのままの場合だけ**埋める |
 | `.env.development` | **キーが空のままの箇所だけ**埋める |
 | `docker.sh` / `docker-compose.development.yml` | **絶対に上書きしない。** 既にあれば読み、仕様書の手動検証表との差分を報告する |
-| `npm install` | 実行する。その `postinstall` が両 hora パッケージからキットを配置する |
+| `npm install` | 実行する。その `postinstall` が4つの hora パッケージからキットを配置する |
 | `bank-id` の backend へのコピー | **まだ無い場合だけ** |
 | 実物ツリーの読み取り | 実行し、読んだ時点の boilerplate タグとともに `.hora/tree/` に控える |
 

--- a/docs/adopting.ja.md
+++ b/docs/adopting.ja.md
@@ -303,7 +303,7 @@ Authority: as-built — what these repositories do is what 1.0.0 is
 | `package.json` の name/description | **プレースホルダのままの場合だけ**埋める |
 | `.env.development` | **キーが空のままの箇所だけ**埋める |
 | `docker.sh` / `docker-compose.development.yml` | **絶対に上書きしない。** 既にあれば読み、仕様書の手動検証表との差分を報告する |
-| `npm install` | 実行する。その `postinstall` が4つの hora パッケージからキットを配置する |
+| `npm install` | 実行する。その `postinstall` がすべての hora-skills パッケージからキットを配置する |
 | `bank-id` の backend へのコピー | **まだ無い場合だけ** |
 | 実物ツリーの読み取り | 実行し、読んだ時点の boilerplate タグとともに `.hora/tree/` に控える |
 

--- a/docs/adopting.md
+++ b/docs/adopting.md
@@ -303,7 +303,7 @@ It works out that repositories are declared but not all set up, and runs `/hora-
 | `package.json` name/description | filled in **only if still a placeholder** |
 | `.env.development` | filled in **only where a key is still empty** |
 | `docker.sh` / `docker-compose.development.yml` | **never overwritten.** If yours exist, they are read, and any difference from the spec's manual-verification table is reported |
-| `npm install` | run, and its `postinstall` equips the kit from all four hora packages |
+| `npm install` | run, and its `postinstall` equips the kit from all hora-skills packages |
 | copying `bank-id` into the backend | **only if not already there** |
 | reading the real tree | run, and cached in `.hora/tree/` with the boilerplate tag it was read at |
 

--- a/docs/adopting.md
+++ b/docs/adopting.md
@@ -303,7 +303,7 @@ It works out that repositories are declared but not all set up, and runs `/hora-
 | `package.json` name/description | filled in **only if still a placeholder** |
 | `.env.development` | filled in **only where a key is still empty** |
 | `docker.sh` / `docker-compose.development.yml` | **never overwritten.** If yours exist, they are read, and any difference from the spec's manual-verification table is reported |
-| `npm install` | run, and its `postinstall` equips the kit from both hora packages |
+| `npm install` | run, and its `postinstall` equips the kit from all four hora packages |
 | copying `bank-id` into the backend | **only if not already there** |
 | reading the real tree | run, and cached in `.hora/tree/` with the boilerplate tag it was read at |
 

--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -44,7 +44,7 @@ Hora Kit が仕様書をアプリケーションに変えるまで。何がど�
 
 **4つのどれも、このリポジトリの中にはありません。** 4層すべてがパッケージとして届き、このリポジトリが持つのは仕様書と、これらの文書と、`.hora/` にある実行自身の記録です。
 
-**驚かれるのは、パッケージ2つの間の分割です。** Hora Kit は GraphQL resolver や Sequelize migration や Vue コンポーネントの書き方を一切持っていません。持ってはいけません — それらは独自にバージョン管理・更新されるパッケージにあります。Hora Kit 側に写しを置けば、そのパッケージが動いた瞬間に食い違い、しかも**食い違ったことを誰も知らせません。** [`structure.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/structure.md) の "The division of labor" と [`skills.ja.md`](./skills.ja.md) を参照してください。
+**驚かれるのは、キットとスキルパッケージの間の分割です。** Hora Kit は GraphQL resolver や Sequelize migration や Vue コンポーネントの書き方を一切持っていません。持ってはいけません — それらはそれぞれ独自にバージョン管理・更新されるパッケージにあります。Hora Kit 側に写しを置けば、そのパッケージが動いた瞬間に食い違い、しかも**食い違ったことを誰も知らせません。** [`structure.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/structure.md) の "The division of labor" と [`skills.ja.md`](./skills.ja.md) を参照してください。
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,7 +44,7 @@ This document explains the design. It is not the authority on any rule — each 
 
 **Not one of the four is in this repository.** All four arrive as packages, and what this repository holds is the spec, these documents, and the run's own record under `.hora/`.
 
-**The split between the two packages is the one that surprises people.** Hora Kit contains no instructions for writing a GraphQL resolver, a Sequelize migration or a Vue component, and it must not — those live in a package that is versioned and updated on its own. A copy inside Hora Kit would disagree with the original the first time that package moved, and nothing would announce that it had. See [`structure.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/structure.md), "The division of labor", and [`skills.md`](./skills.md).
+**The split between the kit and the skills packages is the one that surprises people.** Hora Kit contains no instructions for writing a GraphQL resolver, a Sequelize migration or a Vue component, and it must not — those live in packages that are versioned and updated on their own. A copy inside Hora Kit would disagree with the original the first time that package moved, and nothing would announce that it had. See [`structure.md`](https://github.com/openreachtech/hora-core/blob/main/kit/skills/hora/references/structure.md), "The division of labor", and [`skills.md`](./skills.md).
 
 ---
 


### PR DESCRIPTION
# Why

* Close #97

# How

* `adopting.md` said `postinstall` equips the kit from **both** hora packages. It equips four
* `architecture.md` opened its explanation with "the split between the two packages", and named the skills as living in **a** package versioned on its own. The split now runs between the kit and three skills packages, each versioned on its own
* Two counts the split left behind, in prose that reads correct until you count

`npm run lint:docs-pairs` reports 10 pairs, 0 failures.
