### PR TITLE
🧵 Ignore the support skills record

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,7 @@ id_ed25519
 # and committing it hands everyone else a set of allowances they never granted.
 /.claude/settings.local.json
 
-#### the kit equipped by postinstall, from @openreachtech/hora and the three
+#### the kit equipped by postinstall, from @openreachtech/hora and the four
 #### @openreachtech/hora-skills-ort-* packages (regenerated, not authored here)
 #
 # Ignore the contents of both payload directories, and name this repository's
@@ -62,7 +62,7 @@ id_ed25519
 /.claude/agents/*
 /.claude/skills/*
 
-# The four equip manifests, written by the install commands — one per package,
+# The five equip manifests, written by the install commands — one per package,
 # each named after the package that writes it. These are the only entries under
 # .hora/ that are ignored: everything else there is the run's own record, and
 # `git log .hora/` is the history of what ran.

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ id_ed25519
 /.hora/hora-skills-ort-core.json
 /.hora/hora-skills-ort-furo.json
 /.hora/hora-skills-ort-renchan.json
+/.hora/hora-skills-ort-support.json
 
 #### for Windows
 Thumbs.db

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,7 +43,7 @@ export default [
       '*-backend*/',
       '*-frontend*/',
 
-      // The kit equipped by postinstall, from @openreachtech/hora and the three
+      // The kit equipped by postinstall, from @openreachtech/hora and the four
       // @openreachtech/hora-skills-ort-* packages. Not authored here, and some of the skills
       // ship .js/.mjs/.cjs. Both payload directories are ignored whole, the way
       // .gitignore does it: a denylist written against the names the packages


### PR DESCRIPTION
# Why

* Close #108

# How

* Adds `/.hora/hora-skills-ort-support.json` to the ignored equip manifests. Without it the fourth package`s record would be committed into every project built from this boilerplate — the record is written by the install command, not authored here
* The comments in `.gitignore` and `eslint.config.js` counted three skills packages and four manifests. There are four and five now
