### PR TITLE
📄 Name the support package in `docs/architecture*`

### DIFF
--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -33,14 +33,14 @@ Hora Kit が仕様書をアプリケーションに変えるまで。何がど�
 
 ## 4つの層
 
-![4つの層：/hora、5つの skill、ステージ skill と2つのエージェント、そして3つのスキルパッケージ](./images/layers.ja.svg)
+![4つの層：/hora、5つの skill、ステージ skill と2つのエージェント、そして4つのスキルパッケージ](./images/layers.ja.svg)
 
 | 層 | 決めること | 決してしないこと | 配布元 |
 |---|---|---|---|
 | `/hora` | 次にどの段階が来るか。すべてのブランチ・コミット・マージ | 作業の中身に関する一切 | `@openreachtech/hora` |
 | 5つの skill | 作業の順序と、各関所の終了条件 | その書き方 | `@openreachtech/hora`、および このリポジトリの `/hora-setup` |
 | ステージ skill と2つの agent | 仕様書の1節、あるいは1関所ぶんのコードや判定 | 順序上の位置。git に関する一切 | `@openreachtech/hora` |
-| 3つのスキルパッケージ | **すべての手順と、すべての合否基準** | それが呼ばれる時機 | `@openreachtech/hora-skills-ort-core`・`-ort-renchan`・`-ort-furo` |
+| 4つのスキルパッケージ | **すべての手順と、すべての合否基準** | それが呼ばれる時機 | `@openreachtech/hora-skills-ort-core`・`-ort-renchan`・`-ort-furo`・`-ort-support` |
 
 **4層のうち skill 1つだけがこのリポジトリの中にあり、残りはパッケージとして届きます。** `/hora-setup` は内容がまるごとこのスタックの話なので `kit/skills/` でここが書きます。それ以外は配置されるもので、このリポジトリが持つのは仕様書と、これらの文書と、`.hora/` にある実行自身の記録です。
 
@@ -122,6 +122,7 @@ Hora Kit が仕様書をアプリケーションに変えるまで。何がど�
   hora-skills-ort-core.json     各スキルパッケージの install が置いたもの。
   hora-skills-ort-furo.json     パッケージごとに1ファイル。gitignore 対象
   hora-skills-ort-renchan.json
+  hora-skills-ort-support.json
 ```
 
 `git log .hora/` が「何が走ったか」の履歴です。他に記録している場所はなく、必要もありません。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,14 +33,14 @@ This document explains the design. It is not the authority on any rule — each 
 
 ## Four layers
 
-![Four layers: /hora, the five skills, the stage skills and the two agents, and the three skills packages](./images/layers.svg)
+![Four layers: /hora, the five skills, the stage skills and the two agents, and the four skills packages](./images/layers.svg)
 
 | Layer | What it decides | What it never decides | Ships in |
 |---|---|---|---|
 | `/hora` | which phase comes next; every branch, commit and merge | anything about the work itself | `@openreachtech/hora` |
 | the five skills | the order of the work, and each gate's exit condition | how any of it is written | `@openreachtech/hora`, and `/hora-setup` from this repository |
 | the stage skills and the two agents | one section of the spec, or one checkpoint's code or verdict | where they run in the order; anything about git | `@openreachtech/hora` |
-| the three skills packages | **every procedure and every pass/fail criterion** | when it is invoked | `@openreachtech/hora-skills-ort-core`, `-ort-renchan`, `-ort-furo` |
+| the four skills packages | **every procedure and every pass/fail criterion** | when it is invoked | `@openreachtech/hora-skills-ort-core`, `-ort-renchan`, `-ort-furo`, `-ort-support` |
 
 **One skill of the four layers is in this repository, and the rest arrive as packages.** `/hora-setup` is authored here, under `kit/skills/`, because its whole content is this stack; everything else is installed. What this repository holds besides it is the spec, these documents, and the run's own record under `.hora/`.
 
@@ -124,6 +124,7 @@ There is no state file. **The state is `.hora/`, and its checkboxes are the stat
   hora-skills-ort-core.json     what the last install of each skills package placed —
   hora-skills-ort-furo.json     one record per package. Gitignored
   hora-skills-ort-renchan.json
+  hora-skills-ort-support.json
 ```
 
 `git log .hora/` is the history of what ran. Nothing else records it, and nothing needs to.


### PR DESCRIPTION
# Why

* Close #110

# How

* Names `-ort-support` in the layer table and in the diagram caption, where the document counted three skills packages
* Adds its equip manifest to the `.hora/` listing, which showed one line per package
