### PR TITLE
📄 Name the support package in the remaining documents

### DIFF
--- a/docs/writing-style.ja.md
+++ b/docs/writing-style.ja.md
@@ -6,7 +6,7 @@
 
 この文書は、それらのファイルが従う文体です。書き方の話であって、規則の中身の話ではありません。
 
-**ここで書かれるものではありません。** hora の skill と agent は [`hora-core`](https://github.com/openreachtech/hora-core) で、それらの委譲先である手順は、そのドメインのスキルパッケージ [`hora-skills-ort-core`](https://github.com/openreachtech/hora-skills-ort-core)・[`hora-skills-ort-renchan`](https://github.com/openreachtech/hora-skills-ort-renchan)・[`hora-skills-ort-furo`](https://github.com/openreachtech/hora-skills-ort-furo) で書かれます。このリポジトリはそれを `.claude/` に受け取るだけです。文体は方法論と同じ場所に置く、という理由でここにあります。
+**ここで書かれるものではありません。** hora の skill と agent は [`hora-core`](https://github.com/openreachtech/hora-core) で、それらの委譲先である手順は、そのドメインのスキルパッケージ [`hora-skills-ort-core`](https://github.com/openreachtech/hora-skills-ort-core)・[`hora-skills-ort-renchan`](https://github.com/openreachtech/hora-skills-ort-renchan)・[`hora-skills-ort-furo`](https://github.com/openreachtech/hora-skills-ort-furo)・[`hora-skills-ort-support`](https://github.com/openreachtech/hora-skills-ort-support) で書かれます。このリポジトリはそれを `.claude/` に受け取るだけです。文体は方法論と同じ場所に置く、という理由でここにあります。
 
 ---
 

--- a/docs/writing-style.md
+++ b/docs/writing-style.md
@@ -6,7 +6,7 @@ Every file the two hora packages distribute — every skill and every agent — 
 
 This document is the style those files are held to. It is about wording, never about what the rules say.
 
-**They are not authored here.** The hora skills and agents are written in [`hora-core`](https://github.com/openreachtech/hora-core), the procedures they delegate to in the skills package of their domain — [`hora-skills-ort-core`](https://github.com/openreachtech/hora-skills-ort-core), [`hora-skills-ort-renchan`](https://github.com/openreachtech/hora-skills-ort-renchan) or [`hora-skills-ort-furo`](https://github.com/openreachtech/hora-skills-ort-furo); this repository only receives them, under `.claude/`. The style lives with the method, which is documented here.
+**They are not authored here.** The hora skills and agents are written in [`hora-core`](https://github.com/openreachtech/hora-core), the procedures they delegate to in the skills package of their domain — [`hora-skills-ort-core`](https://github.com/openreachtech/hora-skills-ort-core), [`hora-skills-ort-renchan`](https://github.com/openreachtech/hora-skills-ort-renchan) or [`hora-skills-ort-furo`](https://github.com/openreachtech/hora-skills-ort-furo) or [`hora-skills-ort-support`](https://github.com/openreachtech/hora-skills-ort-support); this repository only receives them, under `.claude/`. The style lives with the method, which is documented here.
 
 ---
 


### PR DESCRIPTION
# Why

* Close #112

# How

* The writing-style document lists the packages a delegated procedure is written in, and named three of the four
* `docs/stack/README*` needs no change: it refers to the packages as `@openreachtech/hora-skills-ort-*`, which already covers the fourth
