### PR TITLE
📦️ Install the support skills package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@openreachtech/hora-skills-ort-core": "^0.0.0",
         "@openreachtech/hora-skills-ort-furo": "^0.0.0",
         "@openreachtech/hora-skills-ort-renchan": "^0.0.0",
+        "@openreachtech/hora-skills-ort-support": "^0.0.0",
         "eslint": "^9.39.5"
       }
     },
@@ -337,6 +338,19 @@
       "license": "Apache-2.0",
       "bin": {
         "hora-skills-ort-renchan": "lib/equip/hora-skills-ort-renchan.js"
+      }
+    },
+    "node_modules/@openreachtech/hora-skills-ort-support": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@openreachtech/hora-skills-ort-support/-/hora-skills-ort-support-0.0.0.tgz",
+      "integrity": "sha512-oKlHQwSK8QMR85/9uOldmCzLXuMua35EKVxoDa25kMxlbmTuwKxHnNuS0kACxBpDLHFU11NB96EQWhc3DcLo3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "hora-skills-ort-support": "lib/equip/hora-skills-ort-support.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@pkgr/core": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "description": "TODO: fulfill here",
   "type": "module",
   "scripts": {
-    "hora:init": "hora-core install && hora-skills-ort-core install && hora-skills-ort-renchan install && hora-skills-ort-furo install && node kit/scripts/equip-own-skills.mjs",
+    "hora:init": "hora-core install && hora-skills-ort-core install && hora-skills-ort-renchan install && hora-skills-ort-furo install && hora-skills-ort-support install && node kit/scripts/equip-own-skills.mjs",
     "l": "npm run lint",
     "lint": "eslint .",
     "lint:docs-pairs": "node scripts/check-docs-pairs.mjs",
@@ -21,6 +21,7 @@
     "@openreachtech/hora-skills-ort-core": "^0.0.0",
     "@openreachtech/hora-skills-ort-furo": "^0.0.0",
     "@openreachtech/hora-skills-ort-renchan": "^0.0.0",
+    "@openreachtech/hora-skills-ort-support": "^0.0.0",
     "eslint": "^9.39.5"
   }
 }


### PR DESCRIPTION
# Why

* Close #107

# How

* Adds `@openreachtech/hora-skills-ort-support` to `devDependencies` and installs it in `hora:init`, before this repository equips its own skill — so `/hos-explain`, `/hos-skillify` and `/hos-user-manual` arrive with the rest
* The lock entry carries the `engines` floor and the bin the package declares, and nothing else in the tree moves
* **The lock was written with npm 12.** `min-release-age-exclude` in `.npmrc` is only honored from npm 12 on — npm 11.14.1 reports it as an unknown config and still quarantines every version younger than seven days, which is every version of this package today
