### PR TITLE
🦵 Kick out `min-release-age-exclude` from `.npmrc`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,7 +2,13 @@
 # install them. Honored by npm >= 11.6 only — an older npm (Node 20's
 # bundled npm 10 included) silently ignores it.
 min-release-age = 7
-min-release-age-exclude = @openreachtech/*
+
+# No scope is exempt, `@openreachtech/*` included. What the window guards
+# against is a version published from a stolen token, and a stolen token
+# publishes under a legitimate scope — so an exemption for the ORT packages
+# would open the hole in front of `postinstall`, the one path here that runs
+# code on every clone. The single command that does need the window off is the
+# lockfile refresh, and the contribution section of the README carries it.
 
 # ⚠️ Never a credential in this file. It is tracked, so a token written here
 # arrives as a modification to a file that is already committed — the one

--- a/README.ja.md
+++ b/README.ja.md
@@ -209,6 +209,14 @@ npm install
 npm run lint
 ```
 
+**`@openreachtech/*` の版を上げるときは、そのコマンドに限ってリリース経過日数の窓を外します。** `.npmrc` は `min-release-age = 7` を設定し、何も免除していません。そのため窓の内側で公開された版へ range を上げて解決すると、古い版で妥協するのではなく `ETARGET` で失敗します。`package.json` の range を上げたら、免除をコマンド自身に渡して lockfile を作り直してください。
+
+```sh
+npm install --min-release-age-exclude="@openreachtech/*"
+```
+
+**ここだけです。`.npmrc` に戻してはいけません。** 常設の免除は、このリポジトリから作られる全てのリポジトリへ渡ります。そしてその免除が前に立つのは `postinstall` — 全ての clone で `hora:init` を走らせるフックです。他にこのフラグが要る場面はありません。`npm ci` と、コミット済みの `package-lock.json` を再利用する `npm install` は、窓に関わらず lock された版を入れます。
+
 **`docs/` 配下は全てペアです** — `x.md` と `x.ja.md`。片方を直したら、同じコミットでもう片方も直してください。同じことを言う文書が2つあれば、片方だけ更新された瞬間に食い違い、しかも古い方も権威ある文面のままです。
 
 **`.claude/` 配下は、ここでは編集しません。** `npm install` が配置する場所で、次の `npm install` が変更を上書きします。hora の skill や agent の修正は [`hora-core`](https://github.com/openreachtech/hora-core)、それらの委譲先である手順の修正は、そのドメインのスキルパッケージ [`hora-skills-ort-core`](https://github.com/openreachtech/hora-skills-ort-core)・[`hora-skills-ort-renchan`](https://github.com/openreachtech/hora-skills-ort-renchan)・[`hora-skills-ort-furo`](https://github.com/openreachtech/hora-skills-ort-furo)・[`hora-skills-ort-support`](https://github.com/openreachtech/hora-skills-ort-support) が置き場所です。いずれも英語のみ — 読み手が言語を選ぶ文書ではなく、Claude Code が読む文書だからです。従う文体は `hora-core` の [`writing-style.ja.md`](https://github.com/openreachtech/hora-core/blob/main/docs/writing-style.ja.md) にあります。

--- a/README.md
+++ b/README.md
@@ -211,6 +211,14 @@ npm install
 npm run lint
 ```
 
+**Raising the `@openreachtech/*` versions needs the release-age window turned off for that one command.** `.npmrc` sets `min-release-age = 7` and exempts nothing, so resolving a range raised to a version published inside that window fails with `ETARGET` rather than quietly settling for an older one. Raise the ranges in `package.json`, then refresh the lockfile with the exemption passed on the command itself.
+
+```sh
+npm install --min-release-age-exclude="@openreachtech/*"
+```
+
+**Only there, and never back in `.npmrc`.** A standing exemption travels to every repository made from this one, and what it would stand in front of is `postinstall` — the hook that runs `hora:init` on every clone. Nothing else asks for the flag: `npm ci`, and any `npm install` that reuses the committed `package-lock.json`, install the locked versions whatever the window says.
+
 **Every file under `docs/` is a pair — `x.md` and `x.ja.md`.** Change one and change the other in the same commit. Two documents saying the same thing will disagree the moment only one of them is updated, and the stale one still reads as authoritative.
 
 **Nothing under `.claude/` is edited here.** It is installed by `npm install`, and the next one overwrites whatever you changed. A fix to a hora skill or an agent belongs in [`hora-core`](https://github.com/openreachtech/hora-core), and one to a procedure they delegate to in the skills package of its domain — [`hora-skills-ort-core`](https://github.com/openreachtech/hora-skills-ort-core), [`hora-skills-ort-renchan`](https://github.com/openreachtech/hora-skills-ort-renchan), [`hora-skills-ort-furo`](https://github.com/openreachtech/hora-skills-ort-furo) or [`hora-skills-ort-support`](https://github.com/openreachtech/hora-skills-ort-support) — all English only, since Claude Code reads them rather than a person choosing a language. [`writing-style.md`](https://github.com/openreachtech/hora-core/blob/main/docs/writing-style.md) in `hora-core` is the style they are held to.


### PR DESCRIPTION
# Why

* Close #133